### PR TITLE
Add AsPrimitive trait for generic casting with `as`

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -462,6 +462,28 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 /// let three: i32 = (3.14159265f32).as_();
 /// assert_eq!(three, 3);
 /// ```
+/// 
+/// # Safety
+/// 
+/// Currently, some uses of the `as` operator are not entirely safe.
+/// In particular, it is undefined behavior if:
+/// 
+/// - A truncated floating point value cannot fit in the target integer
+///   type ([#10184](https://github.com/rust-lang/rust/issues/10184));
+/// 
+/// ```ignore
+/// # use num_traits::AsPrimitive;
+/// let x: u8 = (1.04E+17).as_(); // UB
+/// ```
+/// 
+/// - Or a floating point value does not fit in another floating
+///   point type ([#15536](https://github.com/rust-lang/rust/issues/15536)).
+///
+/// ```ignore
+/// # use num_traits::AsPrimitive;
+/// let x: f32 = (1e300f64).as_(); // UB
+/// ```
+/// 
 pub trait AsPrimitive<T>: 'static + Copy
 where
     T: 'static + Copy

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -493,6 +493,7 @@ impl_as_primitive!(isize => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, 
 impl_as_primitive!(f32 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
 impl_as_primitive!(f64 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
 impl_as_primitive!(char => char, u8, i8, u16, i16, u32, i32, u64, isize, usize, i64);
+impl_as_primitive!(bool => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64);
 
 #[test]
 fn to_primitive_float() {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -452,6 +452,48 @@ impl<T: NumCast> NumCast for Wrapping<T> {
     }
 }
 
+/// A generic interface for casting between machine scalars with the
+/// `as` operator, which admits narrowing and precision loss.
+///
+/// # Examples
+///
+/// ```
+/// # use num_traits::AsPrimitive;
+/// let three: i32 = (3.14159265f32).as_();
+/// assert_eq!(three, 3);
+/// ```
+pub trait AsPrimitive<T>: 'static + Copy
+where
+    T: 'static + Copy
+{
+    /// Convert a value to another, using the `as` operator.
+    fn as_(self) -> T;
+}
+
+macro_rules! impl_as_primitive {
+    ($T: ty => $( $U: ty ),* ) => {
+        $(
+        impl AsPrimitive<$U> for $T {
+            #[inline] fn as_(self) -> $U { self as $U }
+        }
+        )*
+    };
+}
+
+impl_as_primitive!(u8 => char, u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(i8 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(u16 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(i16 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(u32 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(i32 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(u64 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(i64 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(usize => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(isize => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(f32 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(f64 => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64, f32, f64);
+impl_as_primitive!(char => char, u8, i8, u16, i16, u32, i32, u64, isize, usize, i64);
+
 #[test]
 fn to_primitive_float() {
     use std::f32;
@@ -508,4 +550,16 @@ fn wrapping_is_fromprimitive() {
 fn wrapping_is_numcast() {
     fn require_numcast<T: NumCast>(_: &T) {}
     require_numcast(&Wrapping(42));
+}
+
+#[test]
+fn as_primitive() {
+    let x: f32 = (1.625f64).as_();
+    assert_eq!(x, 1.625f32);
+
+    let x: f32 = (3.14159265358979323846f64).as_();
+    assert_eq!(x, 3.1415927f32);
+
+    let x: u8 = (768i16).as_();
+    assert_eq!(x, 0);
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -454,6 +454,9 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 
 /// A generic interface for casting between machine scalars with the
 /// `as` operator, which admits narrowing and precision loss.
+/// Implementers of this trait AsPrimitive should behave like a primitive
+/// numeric type (e.g. a newtype around another primitive), and the
+/// intended conversion must never fail.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This is my personal attempt at #7. It is fairly similar to what can be found in `asprim`, although implemented from scratch. Please let me know of what you think. Could it use more tests? Should I also leave a safety notice that some conversions with `as` are currently UB (rust-lang/rust#10184)? 
