### PR TITLE
Add RealNum trait for real data types (Float, but without floating-point specific features)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::num::Wrapping;
 
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
-// pub use realnum::RealNum; // NOTE: Don't do this, it breaks `use num_traits::*;`.
+// pub use real::Real; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use identities::{Zero, One, zero, one};
 pub use ops::checked::*;
 pub use ops::wrapping::*;
@@ -33,7 +33,7 @@ pub mod sign;
 pub mod ops;
 pub mod bounds;
 pub mod float;
-pub mod realnum;
+pub mod real;
 pub mod cast;
 pub mod int;
 pub mod pow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::num::Wrapping;
 
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
-pub use realnum::RealNum;
+// pub use realnum::RealNum; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use identities::{Zero, One, zero, one};
 pub use ops::checked::*;
 pub use ops::wrapping::*;
@@ -305,8 +305,8 @@ macro_rules! float_trait_impl {
                         };
 
                         match (is_positive, exp) {
-                            (true,  Ok(exp)) => Float::powi(base, exp as i32),
-                            (false, Ok(exp)) => 1.0 / Float::powi(base, exp as i32),
+                            (true,  Ok(exp)) => base.powi(exp as i32),
+                            (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
                             (_, Err(_))      => return Err(PFE { kind: Invalid }),
                         }
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::num::Wrapping;
 
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
+pub use realnum::RealNum;
 pub use identities::{Zero, One, zero, one};
 pub use ops::checked::*;
 pub use ops::wrapping::*;
@@ -32,6 +33,7 @@ pub mod sign;
 pub mod ops;
 pub mod bounds;
 pub mod float;
+pub mod realnum;
 pub mod cast;
 pub mod int;
 pub mod pow;
@@ -303,8 +305,8 @@ macro_rules! float_trait_impl {
                         };
 
                         match (is_positive, exp) {
-                            (true,  Ok(exp)) => base.powi(exp as i32),
-                            (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
+                            (true,  Ok(exp)) => Float::powi(base, exp as i32),
+                            (false, Ok(exp)) => 1.0 / Float::powi(base, exp as i32),
                             (_, Err(_))      => return Err(PFE { kind: Invalid }),
                         }
                     },

--- a/src/real.rs
+++ b/src/real.rs
@@ -3,14 +3,14 @@ use std::ops::Neg;
 use {Num, NumCast, Float};
 
 // NOTE: These doctests have the same issue as those in src/float.rs.
-// They're testing the inherent methods directly, and not those of `RealNum`.
+// They're testing the inherent methods directly, and not those of `Real`.
 
 /// A trait for real number types that do not necessarily have
 /// floating-point-specific characteristics such as NaN and infinity.
 ///
 /// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
 /// for a list of data types that could meaningfully implement this trait.
-pub trait RealNum
+pub trait Real
     : Num
     + Copy
     + NumCast
@@ -20,10 +20,10 @@ pub trait RealNum
     /// Returns the smallest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
-    /// let x: f64 = RealNum::min_value();
+    /// let x: f64 = Real::min_value();
     ///
     /// assert_eq!(x, f64::MIN);
     /// ```
@@ -32,10 +32,10 @@ pub trait RealNum
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
-    /// let x: f64 = RealNum::min_positive_value();
+    /// let x: f64 = Real::min_positive_value();
     ///
     /// assert_eq!(x, f64::MIN_POSITIVE);
     /// ```
@@ -44,10 +44,10 @@ pub trait RealNum
     /// Returns epsilon, a small positive value.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
-    /// let x: f64 = RealNum::epsilon();
+    /// let x: f64 = Real::epsilon();
     ///
     /// assert_eq!(x, f64::EPSILON);
     /// ```
@@ -63,10 +63,10 @@ pub trait RealNum
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
-    /// let x: f64 = RealNum::max_value();
+    /// let x: f64 = Real::max_value();
     /// assert_eq!(x, f64::MAX);
     /// ```
     fn max_value() -> Self;
@@ -74,7 +74,7 @@ pub trait RealNum
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
     /// let g = 3.0;
@@ -87,7 +87,7 @@ pub trait RealNum
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
     /// let g = 4.0;
@@ -101,7 +101,7 @@ pub trait RealNum
     /// `0.0`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
     /// let g = -3.3;
@@ -114,7 +114,7 @@ pub trait RealNum
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
     /// let g = -3.7;
@@ -127,7 +127,7 @@ pub trait RealNum
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
     /// let y = -3.5;
@@ -143,7 +143,7 @@ pub trait RealNum
     /// number is `Float::nan()`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = 3.5;
@@ -166,7 +166,7 @@ pub trait RealNum
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = 3.5;
@@ -182,7 +182,7 @@ pub trait RealNum
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let neg_nan: f64 = -f64::NAN;
@@ -200,7 +200,7 @@ pub trait RealNum
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
@@ -219,7 +219,7 @@ pub trait RealNum
     /// a separate multiplication operation followed by an add.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
     /// let x = 4.0;
@@ -235,7 +235,7 @@ pub trait RealNum
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
@@ -249,7 +249,7 @@ pub trait RealNum
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
@@ -261,7 +261,7 @@ pub trait RealNum
     /// Raise a number to a real number power.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
@@ -276,7 +276,7 @@ pub trait RealNum
     /// If `self` is negative, but not floating-point, the implementation may panic.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
     /// let negative = -4.0;
@@ -291,7 +291,7 @@ pub trait RealNum
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -307,7 +307,7 @@ pub trait RealNum
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
     ///
@@ -321,7 +321,7 @@ pub trait RealNum
     /// Returns the natural logarithm of the number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -337,7 +337,7 @@ pub trait RealNum
     /// Returns the logarithm of the number with respect to an arbitrary base.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
     /// let two = 2.0;
@@ -356,7 +356,7 @@ pub trait RealNum
     /// Returns the base 2 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
     ///
@@ -370,7 +370,7 @@ pub trait RealNum
     /// Returns the base 10 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
     ///
@@ -420,7 +420,7 @@ pub trait RealNum
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -432,7 +432,7 @@ pub trait RealNum
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -447,7 +447,7 @@ pub trait RealNum
     /// * Else: `self - other`
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
     /// let y = -3.0;
@@ -463,7 +463,7 @@ pub trait RealNum
     /// Take the cubic root of a number.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
     ///
@@ -478,7 +478,7 @@ pub trait RealNum
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let y = 3.0;
@@ -493,7 +493,7 @@ pub trait RealNum
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/2.0;
@@ -507,7 +507,7 @@ pub trait RealNum
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = 2.0*f64::consts::PI;
@@ -521,7 +521,7 @@ pub trait RealNum
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -536,7 +536,7 @@ pub trait RealNum
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 2.0;
@@ -553,7 +553,7 @@ pub trait RealNum
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 4.0;
@@ -569,7 +569,7 @@ pub trait RealNum
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
     ///
@@ -588,7 +588,7 @@ pub trait RealNum
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let pi = f64::consts::PI;
@@ -613,7 +613,7 @@ pub trait RealNum
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -631,7 +631,7 @@ pub trait RealNum
     /// number is close to zero.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
     ///
@@ -646,7 +646,7 @@ pub trait RealNum
     /// the operations were performed separately.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x = f64::consts::E - 1.0;
@@ -661,7 +661,7 @@ pub trait RealNum
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -679,7 +679,7 @@ pub trait RealNum
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -697,7 +697,7 @@ pub trait RealNum
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -715,7 +715,7 @@ pub trait RealNum
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let f = x.sinh().asinh();
@@ -729,7 +729,7 @@ pub trait RealNum
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let f = x.cosh().acosh();
@@ -743,7 +743,7 @@ pub trait RealNum
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::realnum::RealNum;
+    /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -756,7 +756,7 @@ pub trait RealNum
     fn atanh(self) -> Self;
 }
 
-impl<T: Float> RealNum for T {
+impl<T: Float> Real for T {
     fn min_value() -> Self {
         Self::min_value()
     }

--- a/src/real.rs
+++ b/src/real.rs
@@ -273,7 +273,10 @@ pub trait Real
     /// Take the square root of a number.
     ///
     /// Returns NaN if `self` is a negative floating-point number.  
-    /// If `self` is negative, but not floating-point, the implementation may panic.
+    ///
+    /// # Panics
+    ///
+    /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
     /// ```
     /// use num_traits::real::Real;
@@ -320,6 +323,10 @@ pub trait Real
 
     /// Returns the natural logarithm of the number.
     ///
+    /// # Panics
+    ///
+    /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
+    ///
     /// ```
     /// use num_traits::real::Real;
     ///
@@ -335,6 +342,10 @@ pub trait Real
     fn ln(self) -> Self;
 
     /// Returns the logarithm of the number with respect to an arbitrary base.
+    ///
+    /// # Panics
+    ///
+    /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
     /// use num_traits::real::Real;
@@ -355,6 +366,10 @@ pub trait Real
 
     /// Returns the base 2 logarithm of the number.
     ///
+    /// # Panics
+    ///
+    /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
+    ///
     /// ```
     /// use num_traits::real::Real;
     ///
@@ -368,6 +383,11 @@ pub trait Real
     fn log2(self) -> Self;
 
     /// Returns the base 10 logarithm of the number.
+    ///
+    /// # Panics
+    ///
+    /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
+    ///
     ///
     /// ```
     /// use num_traits::real::Real;
@@ -535,6 +555,11 @@ pub trait Real
     /// the range [-pi/2, pi/2] or NaN if the number is outside the range
     /// [-1, 1].
     ///
+    /// # Panics
+    ///
+    /// If this type does not support a NaN representation, this function should panic
+    /// if the number is outside the range [-1, 1].
+    ///
     /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
@@ -551,6 +576,11 @@ pub trait Real
     /// Computes the arccosine of a number. Return value is in radians in
     /// the range [0, pi] or NaN if the number is outside the range
     /// [-1, 1].
+    ///
+    /// # Panics
+    ///
+    /// If this type does not support a NaN representation, this function should panic
+    /// if the number is outside the range [-1, 1].
     ///
     /// ```
     /// use num_traits::real::Real;
@@ -644,6 +674,11 @@ pub trait Real
 
     /// Returns `ln(1+n)` (natural logarithm) more accurately than if
     /// the operations were performed separately.
+    ///
+    /// # Panics
+    ///
+    /// If this type does not support a NaN representation, this function should panic
+    /// if `self-1 <= 0`.
     ///
     /// ```
     /// use num_traits::real::Real;

--- a/src/real.rs
+++ b/src/real.rs
@@ -56,9 +56,7 @@ pub trait Real
     ///
     /// The default implementation will panic if `f32::EPSILON` cannot
     /// be cast to `Self`.
-    fn epsilon() -> Self {
-        Self::from(::std::f32::EPSILON).expect("Unable to cast from f32::EPSILON")
-    }
+    fn epsilon() -> Self;
 
     /// Returns the largest finite value that this type can represent.
     ///
@@ -412,12 +410,7 @@ pub trait Real
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[inline]
-    fn to_degrees(self) -> Self {
-        let halfpi = Self::zero().acos();
-        let ninety = Self::from(90u8).unwrap();
-        self * ninety / halfpi
-    }
+    fn to_degrees(self) -> Self;
 
     /// Converts degrees to radians.
     ///
@@ -430,12 +423,7 @@ pub trait Real
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[inline]
-    fn to_radians(self) -> Self {
-        let halfpi = Self::zero().acos();
-        let ninety = Self::from(90u8).unwrap();
-        self * halfpi / ninety
-    }
+    fn to_radians(self) -> Self;
 
     /// Returns the maximum of the two numbers.
     ///

--- a/src/realnum.rs
+++ b/src/realnum.rs
@@ -1,0 +1,901 @@
+use std::ops::Neg;
+
+use {Num, NumCast, Float};
+
+// NOTE: These doctests have the same issue as those in src/float.rs.
+// They're testing the inherent methods directly, and not those of `RealNum`.
+
+/// A trait for real number types that do not necessarily have
+/// floating-point-specific characteristics such as NaN and infinity.
+///
+/// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
+/// for a list of data types that could meaningfully implement this trait.
+pub trait RealNum
+    : Num
+    + Copy
+    + NumCast
+    + PartialOrd
+    + Neg<Output = Self>
+{
+    /// Returns the smallest finite value that this type can represent.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x: f64 = RealNum::min_value();
+    ///
+    /// assert_eq!(x, f64::MIN);
+    /// ```
+    fn min_value() -> Self;
+
+    /// Returns the smallest positive, normalized value that this type can represent.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x: f64 = RealNum::min_positive_value();
+    ///
+    /// assert_eq!(x, f64::MIN_POSITIVE);
+    /// ```
+    fn min_positive_value() -> Self;
+
+    /// Returns epsilon, a small positive value.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x: f64 = RealNum::epsilon();
+    ///
+    /// assert_eq!(x, f64::EPSILON);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// The default implementation will panic if `f32::EPSILON` cannot
+    /// be cast to `Self`.
+    fn epsilon() -> Self {
+        Self::from(::std::f32::EPSILON).expect("Unable to cast from f32::EPSILON")
+    }
+
+    /// Returns the largest finite value that this type can represent.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x: f64 = RealNum::max_value();
+    /// assert_eq!(x, f64::MAX);
+    /// ```
+    fn max_value() -> Self;
+
+    /// Returns the largest integer less than or equal to a number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 3.99;
+    /// let g = 3.0;
+    ///
+    /// assert_eq!(f.floor(), 3.0);
+    /// assert_eq!(g.floor(), 3.0);
+    /// ```
+    fn floor(self) -> Self;
+
+    /// Returns the smallest integer greater than or equal to a number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 3.01;
+    /// let g = 4.0;
+    ///
+    /// assert_eq!(f.ceil(), 4.0);
+    /// assert_eq!(g.ceil(), 4.0);
+    /// ```
+    fn ceil(self) -> Self;
+
+    /// Returns the nearest integer to a number. Round half-way cases away from
+    /// `0.0`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 3.3;
+    /// let g = -3.3;
+    ///
+    /// assert_eq!(f.round(), 3.0);
+    /// assert_eq!(g.round(), -3.0);
+    /// ```
+    fn round(self) -> Self;
+
+    /// Return the integer part of a number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 3.3;
+    /// let g = -3.7;
+    ///
+    /// assert_eq!(f.trunc(), 3.0);
+    /// assert_eq!(g.trunc(), -3.0);
+    /// ```
+    fn trunc(self) -> Self;
+
+    /// Returns the fractional part of a number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 3.5;
+    /// let y = -3.5;
+    /// let abs_difference_x = (x.fract() - 0.5).abs();
+    /// let abs_difference_y = (y.fract() - (-0.5)).abs();
+    ///
+    /// assert!(abs_difference_x < 1e-10);
+    /// assert!(abs_difference_y < 1e-10);
+    /// ```
+    fn fract(self) -> Self;
+
+    /// Computes the absolute value of `self`. Returns `Float::nan()` if the
+    /// number is `Float::nan()`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = 3.5;
+    /// let y = -3.5;
+    ///
+    /// let abs_difference_x = (x.abs() - x).abs();
+    /// let abs_difference_y = (y.abs() - (-y)).abs();
+    ///
+    /// assert!(abs_difference_x < 1e-10);
+    /// assert!(abs_difference_y < 1e-10);
+    ///
+    /// assert!(::num_traits::Float::is_nan(f64::NAN.abs()));
+    /// ```
+    fn abs(self) -> Self;
+
+    /// Returns a number that represents the sign of `self`.
+    ///
+    /// - `1.0` if the number is positive, `+0.0` or `Float::infinity()`
+    /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
+    /// - `Float::nan()` if the number is `Float::nan()`
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let f = 3.5;
+    ///
+    /// assert_eq!(f.signum(), 1.0);
+    /// assert_eq!(f64::NEG_INFINITY.signum(), -1.0);
+    ///
+    /// assert!(f64::NAN.signum().is_nan());
+    /// ```
+    fn signum(self) -> Self;
+
+    /// Returns `true` if `self` is positive, including `+0.0`,
+    /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let neg_nan: f64 = -f64::NAN;
+    ///
+    /// let f = 7.0;
+    /// let g = -7.0;
+    ///
+    /// assert!(f.is_sign_positive());
+    /// assert!(!g.is_sign_positive());
+    /// assert!(!neg_nan.is_sign_positive());
+    /// ```
+    fn is_sign_positive(self) -> bool;
+
+    /// Returns `true` if `self` is negative, including `-0.0`,
+    /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let nan: f64 = f64::NAN;
+    ///
+    /// let f = 7.0;
+    /// let g = -7.0;
+    ///
+    /// assert!(!f.is_sign_negative());
+    /// assert!(g.is_sign_negative());
+    /// assert!(!nan.is_sign_negative());
+    /// ```
+    fn is_sign_negative(self) -> bool;
+
+    /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
+    /// error. This produces a more accurate result with better performance than
+    /// a separate multiplication operation followed by an add.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let m = 10.0;
+    /// let x = 4.0;
+    /// let b = 60.0;
+    ///
+    /// // 100.0
+    /// let abs_difference = (m.mul_add(x, b) - (m*x + b)).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn mul_add(self, a: Self, b: Self) -> Self;
+
+    /// Take the reciprocal (inverse) of a number, `1/x`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 2.0;
+    /// let abs_difference = (x.recip() - (1.0/x)).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn recip(self) -> Self;
+
+    /// Raise a number to an integer power.
+    ///
+    /// Using this function is generally faster than using `powf`
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 2.0;
+    /// let abs_difference = (x.powi(2) - x*x).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn powi(self, n: i32) -> Self;
+
+    /// Raise a number to a real number power.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 2.0;
+    /// let abs_difference = (x.powf(2.0) - x*x).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn powf(self, n: Self) -> Self;
+
+    /// Take the square root of a number.
+    ///
+    /// Returns NaN if `self` is a negative floating-point number.  
+    /// If `self` is negative, but not floating-point, the implementation may panic.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let positive = 4.0;
+    /// let negative = -4.0;
+    ///
+    /// let abs_difference = (positive.sqrt() - 2.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// assert!(::num_traits::Float::is_nan(negative.sqrt()));
+    /// ```
+    fn sqrt(self) -> Self;
+
+    /// Returns `e^(self)`, (the exponential function).
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let one = 1.0;
+    /// // e^1
+    /// let e = one.exp();
+    ///
+    /// // ln(e) - 1 == 0
+    /// let abs_difference = (e.ln() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn exp(self) -> Self;
+
+    /// Returns `2^(self)`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 2.0;
+    ///
+    /// // 2^2 - 4 == 0
+    /// let abs_difference = (f.exp2() - 4.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn exp2(self) -> Self;
+
+    /// Returns the natural logarithm of the number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let one = 1.0;
+    /// // e^1
+    /// let e = one.exp();
+    ///
+    /// // ln(e) - 1 == 0
+    /// let abs_difference = (e.ln() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn ln(self) -> Self;
+
+    /// Returns the logarithm of the number with respect to an arbitrary base.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let ten = 10.0;
+    /// let two = 2.0;
+    ///
+    /// // log10(10) - 1 == 0
+    /// let abs_difference_10 = (ten.log(10.0) - 1.0).abs();
+    ///
+    /// // log2(2) - 1 == 0
+    /// let abs_difference_2 = (two.log(2.0) - 1.0).abs();
+    ///
+    /// assert!(abs_difference_10 < 1e-10);
+    /// assert!(abs_difference_2 < 1e-10);
+    /// ```
+    fn log(self, base: Self) -> Self;
+
+    /// Returns the base 2 logarithm of the number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let two = 2.0;
+    ///
+    /// // log2(2) - 1 == 0
+    /// let abs_difference = (two.log2() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn log2(self) -> Self;
+
+    /// Returns the base 10 logarithm of the number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let ten = 10.0;
+    ///
+    /// // log10(10) - 1 == 0
+    /// let abs_difference = (ten.log10() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn log10(self) -> Self;
+
+    /// Converts radians to degrees.
+    ///
+    /// ```
+    /// use std::f64::consts;
+    ///
+    /// let angle = consts::PI;
+    ///
+    /// let abs_difference = (angle.to_degrees() - 180.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    #[inline]
+    fn to_degrees(self) -> Self {
+        let halfpi = Self::zero().acos();
+        let ninety = Self::from(90u8).unwrap();
+        self * ninety / halfpi
+    }
+
+    /// Converts degrees to radians.
+    ///
+    /// ```
+    /// use std::f64::consts;
+    ///
+    /// let angle = 180.0_f64;
+    ///
+    /// let abs_difference = (angle.to_radians() - consts::PI).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    #[inline]
+    fn to_radians(self) -> Self {
+        let halfpi = Self::zero().acos();
+        let ninety = Self::from(90u8).unwrap();
+        self * halfpi / ninety
+    }
+
+    /// Returns the maximum of the two numbers.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 1.0;
+    /// let y = 2.0;
+    ///
+    /// assert_eq!(x.max(y), y);
+    /// ```
+    fn max(self, other: Self) -> Self;
+
+    /// Returns the minimum of the two numbers.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 1.0;
+    /// let y = 2.0;
+    ///
+    /// assert_eq!(x.min(y), x);
+    /// ```
+    fn min(self, other: Self) -> Self;
+
+    /// The positive difference of two numbers.
+    ///
+    /// * If `self <= other`: `0:0`
+    /// * Else: `self - other`
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 3.0;
+    /// let y = -3.0;
+    ///
+    /// let abs_difference_x = (x.abs_sub(1.0) - 2.0).abs();
+    /// let abs_difference_y = (y.abs_sub(1.0) - 0.0).abs();
+    ///
+    /// assert!(abs_difference_x < 1e-10);
+    /// assert!(abs_difference_y < 1e-10);
+    /// ```
+    fn abs_sub(self, other: Self) -> Self;
+
+    /// Take the cubic root of a number.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 8.0;
+    ///
+    /// // x^(1/3) - 2 == 0
+    /// let abs_difference = (x.cbrt() - 2.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn cbrt(self) -> Self;
+
+    /// Calculate the length of the hypotenuse of a right-angle triangle given
+    /// legs of length `x` and `y`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 2.0;
+    /// let y = 3.0;
+    ///
+    /// // sqrt(x^2 + y^2)
+    /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn hypot(self, other: Self) -> Self;
+
+    /// Computes the sine of a number (in radians).
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = f64::consts::PI/2.0;
+    ///
+    /// let abs_difference = (x.sin() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn sin(self) -> Self;
+
+    /// Computes the cosine of a number (in radians).
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = 2.0*f64::consts::PI;
+    ///
+    /// let abs_difference = (x.cos() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn cos(self) -> Self;
+
+    /// Computes the tangent of a number (in radians).
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = f64::consts::PI/4.0;
+    /// let abs_difference = (x.tan() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-14);
+    /// ```
+    fn tan(self) -> Self;
+
+    /// Computes the arcsine of a number. Return value is in radians in
+    /// the range [-pi/2, pi/2] or NaN if the number is outside the range
+    /// [-1, 1].
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let f = f64::consts::PI / 2.0;
+    ///
+    /// // asin(sin(pi/2))
+    /// let abs_difference = (f.sin().asin() - f64::consts::PI / 2.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn asin(self) -> Self;
+
+    /// Computes the arccosine of a number. Return value is in radians in
+    /// the range [0, pi] or NaN if the number is outside the range
+    /// [-1, 1].
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let f = f64::consts::PI / 4.0;
+    ///
+    /// // acos(cos(pi/4))
+    /// let abs_difference = (f.cos().acos() - f64::consts::PI / 4.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn acos(self) -> Self;
+
+    /// Computes the arctangent of a number. Return value is in radians in the
+    /// range [-pi/2, pi/2];
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let f = 1.0;
+    ///
+    /// // atan(tan(1))
+    /// let abs_difference = (f.tan().atan() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn atan(self) -> Self;
+
+    /// Computes the four quadrant arctangent of `self` (`y`) and `other` (`x`).
+    ///
+    /// * `x = 0`, `y = 0`: `0`
+    /// * `x >= 0`: `arctan(y/x)` -> `[-pi/2, pi/2]`
+    /// * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
+    /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let pi = f64::consts::PI;
+    /// // All angles from horizontal right (+x)
+    /// // 45 deg counter-clockwise
+    /// let x1 = 3.0;
+    /// let y1 = -3.0;
+    ///
+    /// // 135 deg clockwise
+    /// let x2 = -3.0;
+    /// let y2 = 3.0;
+    ///
+    /// let abs_difference_1 = (y1.atan2(x1) - (-pi/4.0)).abs();
+    /// let abs_difference_2 = (y2.atan2(x2) - 3.0*pi/4.0).abs();
+    ///
+    /// assert!(abs_difference_1 < 1e-10);
+    /// assert!(abs_difference_2 < 1e-10);
+    /// ```
+    fn atan2(self, other: Self) -> Self;
+
+    /// Simultaneously computes the sine and cosine of the number, `x`. Returns
+    /// `(sin(x), cos(x))`.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = f64::consts::PI/4.0;
+    /// let f = x.sin_cos();
+    ///
+    /// let abs_difference_0 = (f.0 - x.sin()).abs();
+    /// let abs_difference_1 = (f.1 - x.cos()).abs();
+    ///
+    /// assert!(abs_difference_0 < 1e-10);
+    /// assert!(abs_difference_0 < 1e-10);
+    /// ```
+    fn sin_cos(self) -> (Self, Self);
+
+    /// Returns `e^(self) - 1` in a way that is accurate even if the
+    /// number is close to zero.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 7.0;
+    ///
+    /// // e^(ln(7)) - 1
+    /// let abs_difference = (x.ln().exp_m1() - 6.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn exp_m1(self) -> Self;
+
+    /// Returns `ln(1+n)` (natural logarithm) more accurately than if
+    /// the operations were performed separately.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let x = f64::consts::E - 1.0;
+    ///
+    /// // ln(1 + (e - 1)) == ln(e) == 1
+    /// let abs_difference = (x.ln_1p() - 1.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn ln_1p(self) -> Self;
+
+    /// Hyperbolic sine function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let e = f64::consts::E;
+    /// let x = 1.0;
+    ///
+    /// let f = x.sinh();
+    /// // Solving sinh() at 1 gives `(e^2-1)/(2e)`
+    /// let g = (e*e - 1.0)/(2.0*e);
+    /// let abs_difference = (f - g).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    fn sinh(self) -> Self;
+
+    /// Hyperbolic cosine function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let e = f64::consts::E;
+    /// let x = 1.0;
+    /// let f = x.cosh();
+    /// // Solving cosh() at 1 gives this result
+    /// let g = (e*e + 1.0)/(2.0*e);
+    /// let abs_difference = (f - g).abs();
+    ///
+    /// // Same result
+    /// assert!(abs_difference < 1.0e-10);
+    /// ```
+    fn cosh(self) -> Self;
+
+    /// Hyperbolic tangent function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let e = f64::consts::E;
+    /// let x = 1.0;
+    ///
+    /// let f = x.tanh();
+    /// // Solving tanh() at 1 gives `(1 - e^(-2))/(1 + e^(-2))`
+    /// let g = (1.0 - e.powi(-2))/(1.0 + e.powi(-2));
+    /// let abs_difference = (f - g).abs();
+    ///
+    /// assert!(abs_difference < 1.0e-10);
+    /// ```
+    fn tanh(self) -> Self;
+
+    /// Inverse hyperbolic sine function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 1.0;
+    /// let f = x.sinh().asinh();
+    ///
+    /// let abs_difference = (f - x).abs();
+    ///
+    /// assert!(abs_difference < 1.0e-10);
+    /// ```
+    fn asinh(self) -> Self;
+
+    /// Inverse hyperbolic cosine function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    ///
+    /// let x = 1.0;
+    /// let f = x.cosh().acosh();
+    ///
+    /// let abs_difference = (f - x).abs();
+    ///
+    /// assert!(abs_difference < 1.0e-10);
+    /// ```
+    fn acosh(self) -> Self;
+
+    /// Inverse hyperbolic tangent function.
+    ///
+    /// ```
+    /// use num_traits::RealNum;
+    /// use std::f64;
+    ///
+    /// let e = f64::consts::E;
+    /// let f = e.tanh().atanh();
+    ///
+    /// let abs_difference = (f - e).abs();
+    ///
+    /// assert!(abs_difference < 1.0e-10);
+    /// ```
+    fn atanh(self) -> Self;
+}
+
+impl<T: Float> RealNum for T {
+    fn min_value() -> Self {
+        Self::min_value()
+    }
+    fn min_positive_value() -> Self {
+        Self::min_positive_value()
+    }
+    fn epsilon() -> Self {
+        Self::epsilon()
+    }
+    fn max_value() -> Self {
+        Self::max_value()
+    }
+    fn floor(self) -> Self {
+        self.floor()
+    }
+    fn ceil(self) -> Self {
+        self.ceil()
+    }
+    fn round(self) -> Self {
+        self.round()
+    }
+    fn trunc(self) -> Self {
+        self.trunc()
+    }
+    fn fract(self) -> Self {
+        self.fract()
+    }
+    fn abs(self) -> Self {
+        self.abs()
+    }
+    fn signum(self) -> Self {
+        self.signum()
+    }
+    fn is_sign_positive(self) -> bool {
+        self.is_sign_positive()
+    }
+    fn is_sign_negative(self) -> bool {
+        self.is_sign_negative()
+    }
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        self.mul_add(a, b)
+    }
+    fn recip(self) -> Self {
+        self.recip()
+    }
+    fn powi(self, n: i32) -> Self {
+        self.powi(n)
+    }
+    fn powf(self, n: Self) -> Self {
+        self.powf(n)
+    }
+    fn sqrt(self) -> Self {
+        self.sqrt()
+    }
+    fn exp(self) -> Self {
+        self.exp()
+    }
+    fn exp2(self) -> Self {
+        self.exp2()
+    }
+    fn ln(self) -> Self {
+        self.ln()
+    }
+    fn log(self, base: Self) -> Self {
+        self.log(base)
+    }
+    fn log2(self) -> Self {
+        self.log2()
+    }
+    fn log10(self) -> Self {
+        self.log10()
+    }
+    fn to_degrees(self) -> Self {
+        self.to_degrees()
+    }
+    fn to_radians(self) -> Self {
+        self.to_radians()
+    }
+    fn max(self, other: Self) -> Self {
+        self.max(other)
+    }
+    fn min(self, other: Self) -> Self {
+        self.min(other)
+    }
+    fn abs_sub(self, other: Self) -> Self {
+        self.abs_sub(other)
+    }
+    fn cbrt(self) -> Self {
+        self.cbrt()
+    }
+    fn hypot(self, other: Self) -> Self {
+        self.hypot(other)
+    }
+    fn sin(self) -> Self {
+        self.sin()
+    }
+    fn cos(self) -> Self {
+        self.cos()
+    }
+    fn tan(self) -> Self {
+        self.tan()
+    }
+    fn asin(self) -> Self {
+        self.asin()
+    }
+    fn acos(self) -> Self {
+        self.acos()
+    }
+    fn atan(self) -> Self {
+        self.atan()
+    }
+    fn atan2(self, other: Self) -> Self {
+        self.atan2(other)
+    }
+    fn sin_cos(self) -> (Self, Self) {
+        self.sin_cos()
+    }
+    fn exp_m1(self) -> Self {
+        self.exp_m1()
+    }
+    fn ln_1p(self) -> Self {
+        self.ln_1p()
+    }
+    fn sinh(self) -> Self {
+        self.sinh()
+    }
+    fn cosh(self) -> Self {
+        self.cosh()
+    }
+    fn tanh(self) -> Self {
+        self.tanh()
+    }
+    fn asinh(self) -> Self {
+        self.asinh()
+    }
+    fn acosh(self) -> Self {
+        self.acosh()
+    }
+    fn atanh(self) -> Self {
+        self.atanh()
+    }
+}

--- a/src/realnum.rs
+++ b/src/realnum.rs
@@ -20,7 +20,7 @@ pub trait RealNum
     /// Returns the smallest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x: f64 = RealNum::min_value();
@@ -32,7 +32,7 @@ pub trait RealNum
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x: f64 = RealNum::min_positive_value();
@@ -44,7 +44,7 @@ pub trait RealNum
     /// Returns epsilon, a small positive value.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x: f64 = RealNum::epsilon();
@@ -63,7 +63,7 @@ pub trait RealNum
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x: f64 = RealNum::max_value();
@@ -74,7 +74,7 @@ pub trait RealNum
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 3.99;
     /// let g = 3.0;
@@ -87,7 +87,7 @@ pub trait RealNum
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 3.01;
     /// let g = 4.0;
@@ -101,7 +101,7 @@ pub trait RealNum
     /// `0.0`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 3.3;
     /// let g = -3.3;
@@ -114,7 +114,7 @@ pub trait RealNum
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 3.3;
     /// let g = -3.7;
@@ -127,7 +127,7 @@ pub trait RealNum
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 3.5;
     /// let y = -3.5;
@@ -143,7 +143,7 @@ pub trait RealNum
     /// number is `Float::nan()`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = 3.5;
@@ -166,7 +166,7 @@ pub trait RealNum
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let f = 3.5;
@@ -182,7 +182,7 @@ pub trait RealNum
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let neg_nan: f64 = -f64::NAN;
@@ -200,7 +200,7 @@ pub trait RealNum
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
@@ -219,7 +219,7 @@ pub trait RealNum
     /// a separate multiplication operation followed by an add.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let m = 10.0;
     /// let x = 4.0;
@@ -235,7 +235,7 @@ pub trait RealNum
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
@@ -249,7 +249,7 @@ pub trait RealNum
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
@@ -261,7 +261,7 @@ pub trait RealNum
     /// Raise a number to a real number power.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
@@ -276,7 +276,7 @@ pub trait RealNum
     /// If `self` is negative, but not floating-point, the implementation may panic.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let positive = 4.0;
     /// let negative = -4.0;
@@ -291,7 +291,7 @@ pub trait RealNum
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -307,7 +307,7 @@ pub trait RealNum
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 2.0;
     ///
@@ -321,7 +321,7 @@ pub trait RealNum
     /// Returns the natural logarithm of the number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let one = 1.0;
     /// // e^1
@@ -337,7 +337,7 @@ pub trait RealNum
     /// Returns the logarithm of the number with respect to an arbitrary base.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let ten = 10.0;
     /// let two = 2.0;
@@ -356,7 +356,7 @@ pub trait RealNum
     /// Returns the base 2 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let two = 2.0;
     ///
@@ -370,7 +370,7 @@ pub trait RealNum
     /// Returns the base 10 logarithm of the number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let ten = 10.0;
     ///
@@ -420,7 +420,7 @@ pub trait RealNum
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -432,7 +432,7 @@ pub trait RealNum
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
@@ -447,7 +447,7 @@ pub trait RealNum
     /// * Else: `self - other`
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 3.0;
     /// let y = -3.0;
@@ -463,7 +463,7 @@ pub trait RealNum
     /// Take the cubic root of a number.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 8.0;
     ///
@@ -478,7 +478,7 @@ pub trait RealNum
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 2.0;
     /// let y = 3.0;
@@ -493,7 +493,7 @@ pub trait RealNum
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/2.0;
@@ -507,7 +507,7 @@ pub trait RealNum
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = 2.0*f64::consts::PI;
@@ -521,7 +521,7 @@ pub trait RealNum
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -536,7 +536,7 @@ pub trait RealNum
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 2.0;
@@ -553,7 +553,7 @@ pub trait RealNum
     /// [-1, 1].
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 4.0;
@@ -569,7 +569,7 @@ pub trait RealNum
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let f = 1.0;
     ///
@@ -588,7 +588,7 @@ pub trait RealNum
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let pi = f64::consts::PI;
@@ -613,7 +613,7 @@ pub trait RealNum
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -631,7 +631,7 @@ pub trait RealNum
     /// number is close to zero.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 7.0;
     ///
@@ -646,7 +646,7 @@ pub trait RealNum
     /// the operations were performed separately.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let x = f64::consts::E - 1.0;
@@ -661,7 +661,7 @@ pub trait RealNum
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -679,7 +679,7 @@ pub trait RealNum
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -697,7 +697,7 @@ pub trait RealNum
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -715,7 +715,7 @@ pub trait RealNum
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 1.0;
     /// let f = x.sinh().asinh();
@@ -729,7 +729,7 @@ pub trait RealNum
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     ///
     /// let x = 1.0;
     /// let f = x.cosh().acosh();
@@ -743,7 +743,7 @@ pub trait RealNum
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// use num_traits::RealNum;
+    /// use num_traits::realnum::RealNum;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;


### PR DESCRIPTION
This is supposed to fix [#19](https://github.com/rust-num/num-traits/issues/19); I assumed going ahead would be better than bumping the thread.  

In any case, I understand that it is a quite significant addition and won't mind too much if it doesn't make it.

This adds a new `RealNum` trait, along with a universal impl `impl<T: Float> RealNum for T { ... }`.  
Therefore, this shouldn't be a breaking change, except in places where both traits are imported (which obviously only happened in a few places in this crate).

The intent is that generic code may prefer to use `RealNum` instead of `Float` when floating-point isn't a requirement. In the future (next major version ?), I guess `Float` could be made to only provide floating-point-specific features on top of `RealNum`.

Most of the code+doc was copy-pasted from `Float`, but the doc comments should be up-to-date with the situation; `Float` only makes an appearance when talking about NaN and infinity.

Issues I've seen : 
- `RealNum` might not be the name we want;
- I've mentioned that `sqrt()` is allowed to panic if the input is negative and has no meaningful NaN representation;
- Should we do that too for e.g `log()` ? Like `sqrt()`, it's supposed to return Nan when `x < 0`.

Thanks for your time. :)