### PR TITLE
Replaced fn one() and fn zero() by associated consts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "algorithms", "science" ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-num/num-traits"
 name = "num-traits"
-version = "0.1.41"
+version = "0.2.0"
 readme = "README.md"
 
 [dependencies]

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -5,21 +5,25 @@ use std::num::Wrapping;
 
 /// Numbers which have upper and lower bounds
 pub trait Bounded {
-    // FIXME (#5527): These should be associated constants
     /// returns the smallest finite number this type can represent
-    fn min_value() -> Self;
+    const MIN: Self;
+    #[inline]
+    fn min_value() -> Self where Self: Sized {
+        Self::MIN
+    }
     /// returns the largest finite number this type can represent
-    fn max_value() -> Self;
+    const MAX: Self;
+    #[inline]
+    fn max_value() -> Self where Self: Sized {
+        Self::MAX
+    }
 }
 
 macro_rules! bounded_impl {
     ($t:ty, $min:expr, $max:expr) => {
         impl Bounded for $t {
-            #[inline]
-            fn min_value() -> $t { $min }
-
-            #[inline]
-            fn max_value() -> $t { $max }
+            const MIN: $t = $min;
+            const MAX: $t = $max;
         }
     }
 }
@@ -37,8 +41,9 @@ bounded_impl!(i32,   i32::MIN,   i32::MAX);
 bounded_impl!(i64,   i64::MIN,   i64::MAX);
 
 impl<T: Bounded> Bounded for Wrapping<T> {
-    fn min_value() -> Self { Wrapping(T::min_value()) }
-    fn max_value() -> Self { Wrapping(T::max_value()) }
+
+    const MIN: Self = Wrapping(T::MIN);
+    const MAX: Self = Wrapping(T::MAX);
 }
 
 bounded_impl!(f32, f32::MIN, f32::MAX);
@@ -61,14 +66,8 @@ macro_rules! for_each_tuple {
 macro_rules! bounded_tuple {
     ( $($name:ident)* ) => (
         impl<$($name: Bounded,)*> Bounded for ($($name,)*) {
-            #[inline]
-            fn min_value() -> Self {
-                ($($name::min_value(),)*)
-            }
-            #[inline]
-            fn max_value() -> Self {
-                ($($name::max_value(),)*)
-            }
+            const MIN: Self = ($($name::MIN,)*);
+            const MAX: Self = ($($name::MAX,)*);
         }
     );
 }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -17,7 +17,6 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// This function should return the same result at all times regardless of
     /// external mutable state, for example values stored in TLS or in
     /// `static mut`s.
-    // FIXME (#5527): This should be an associated constant
     const ZERO: Self;
     
     #[inline]
@@ -83,7 +82,6 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// This function should return the same result at all times regardless of
     /// external mutable state, for example values stored in TLS or in
     /// `static mut`s.
-    // FIXME (#5527): This should be an associated constant
     const ONE: Self;
 
     #[inline]

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -20,6 +20,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     // FIXME (#5527): This should be an associated constant
     const ZERO: Self;
     
+    #[inline]
     fn zero() -> Self {
         Self::ZERO
     }
@@ -85,6 +86,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     // FIXME (#5527): This should be an associated constant
     const ONE: Self;
 
+    #[inline]
     fn one() -> Self {
         Self::ONE
     }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -18,7 +18,11 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// external mutable state, for example values stored in TLS or in
     /// `static mut`s.
     // FIXME (#5527): This should be an associated constant
-    fn zero() -> Self;
+    const ZERO: Self;
+    
+    fn zero() -> Self {
+        Self::ZERO
+    }
 
     /// Returns `true` if `self` is equal to the additive identity.
     #[inline]
@@ -28,6 +32,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
         impl Zero for $t {
+            const ZERO: $t = $v;
             #[inline]
             fn zero() -> $t { $v }
             #[inline]
@@ -52,12 +57,12 @@ zero_impl!(f32, 0.0f32);
 zero_impl!(f64, 0.0f64);
 
 impl<T: Zero> Zero for Wrapping<T> where Wrapping<T>: Add<Output=Wrapping<T>> {
+    
+
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
-    fn zero() -> Self {
-        Wrapping(T::zero())
-    }
+    const ZERO: Self = Wrapping(T::ZERO);
 }
 
 
@@ -78,12 +83,17 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// external mutable state, for example values stored in TLS or in
     /// `static mut`s.
     // FIXME (#5527): This should be an associated constant
-    fn one() -> Self;
+    const ONE: Self;
+
+    fn one() -> Self {
+        Self::ONE
+    }
 }
 
 macro_rules! one_impl {
     ($t:ty, $v:expr) => {
         impl One for $t {
+            const ONE: $t = $v;
             #[inline]
             fn one() -> $t { $v }
         }
@@ -106,9 +116,7 @@ one_impl!(f32, 1.0f32);
 one_impl!(f64, 1.0f64);
 
 impl<T: One> One for Wrapping<T> where Wrapping<T>: Mul<Output=Wrapping<T>> {
-    fn one() -> Self {
-        Wrapping(T::one())
-    }
+    const ONE: Self = Wrapping(T::ONE);
 }
 
 // Some helper functions provided for backwards compatibility.


### PR DESCRIPTION
The new consts, every trait One and Zero have to implement are called ONE and ZERO.
For backwards compatability, the functions are not deleted, so using such types will still be possible as before.
But implementors, who update the version would need to update their trait implementations, using these consants.
It's not possible to define the functions as associated const fn, and set them as default value for the new constants.
So I updated the version to `0.2.0`.
I also removed the fixme messages for #5527
In order to reduce breaking changes, I also updated the bounded trait and it's impls
New implementations will only have to implement the constants, the functions have default implementations retruning the constant.
