### PR TITLE
Check overflow when casting floats to integers.

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -655,9 +655,4 @@ fn float_to_integer_checks_overflow() {
 
     // Expect the overflow to be caught
     assert_eq!(source.to_i32(), None);
-
-    // Specifically make sure we didn't silently let the overflow through
-    // (This line is mostly for humans -- the robots should catch any problem
-    // on the line above).
-    assert!(source.to_i32() != Some(-2147483648));
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -236,35 +236,93 @@ macro_rules! impl_to_primitive_float_to_float {
     )
 }
 
+macro_rules! impl_to_primitive_float_to_signed_int {
+    ($SrcT:ident, $DstT:ident, $slf:expr) => (
+        if size_of::<$SrcT>() <= size_of::<$DstT>() {
+            Some($slf as $DstT)
+        } else {
+            // Make sure the value is in range for the cast.
+            let n = $slf as $DstT;
+            let max_value: $DstT = ::std::$DstT::MAX;
+            if -max_value as $DstT <= n && n <= max_value as $DstT {
+                Some($slf as $DstT)
+            } else {
+                None
+            }
+        }
+    )
+}
+
+macro_rules! impl_to_primitive_float_to_unsigned_int {
+    ($SrcT:ident, $DstT:ident, $slf:expr) => (
+        if size_of::<$SrcT>() <= size_of::<$DstT>() {
+            Some($slf as $DstT)
+        } else {
+            // Make sure the value is in range for the cast.
+            let n = $slf as $DstT;
+            let max_value: $DstT = ::std::$DstT::MAX;
+            if n <= max_value as $DstT {
+                Some($slf as $DstT)
+            } else {
+                None
+            }
+        }
+    )
+}
+
 macro_rules! impl_to_primitive_float {
     ($T:ident) => (
         impl ToPrimitive for $T {
             #[inline]
-            fn to_isize(&self) -> Option<isize> { Some(*self as isize) }
+            fn to_isize(&self) -> Option<isize> {
+                impl_to_primitive_float_to_signed_int!($T, isize, *self)
+            }
             #[inline]
-            fn to_i8(&self) -> Option<i8> { Some(*self as i8) }
+            fn to_i8(&self) -> Option<i8> {
+                impl_to_primitive_float_to_signed_int!($T, i8, *self)
+            }
             #[inline]
-            fn to_i16(&self) -> Option<i16> { Some(*self as i16) }
+            fn to_i16(&self) -> Option<i16> {
+                impl_to_primitive_float_to_signed_int!($T, i16, *self)
+            }
             #[inline]
-            fn to_i32(&self) -> Option<i32> { Some(*self as i32) }
+            fn to_i32(&self) -> Option<i32> {
+                impl_to_primitive_float_to_signed_int!($T, i32, *self)
+            }
             #[inline]
-            fn to_i64(&self) -> Option<i64> { Some(*self as i64) }
+            fn to_i64(&self) -> Option<i64> {
+                impl_to_primitive_float_to_signed_int!($T, i64, *self)
+            }
 
             #[inline]
-            fn to_usize(&self) -> Option<usize> { Some(*self as usize) }
+            fn to_usize(&self) -> Option<usize> {
+                impl_to_primitive_float_to_unsigned_int!($T, usize, *self)
+            }
             #[inline]
-            fn to_u8(&self) -> Option<u8> { Some(*self as u8) }
+            fn to_u8(&self) -> Option<u8> {
+                impl_to_primitive_float_to_unsigned_int!($T, u8, *self)
+            }
             #[inline]
-            fn to_u16(&self) -> Option<u16> { Some(*self as u16) }
+            fn to_u16(&self) -> Option<u16> {
+                impl_to_primitive_float_to_unsigned_int!($T, u16, *self)
+            }
             #[inline]
-            fn to_u32(&self) -> Option<u32> { Some(*self as u32) }
+            fn to_u32(&self) -> Option<u32> {
+                impl_to_primitive_float_to_unsigned_int!($T, u32, *self)
+            }
             #[inline]
-            fn to_u64(&self) -> Option<u64> { Some(*self as u64) }
+            fn to_u64(&self) -> Option<u64> {
+                impl_to_primitive_float_to_unsigned_int!($T, u64, *self)
+            }
 
             #[inline]
-            fn to_f32(&self) -> Option<f32> { impl_to_primitive_float_to_float!($T, f32, *self) }
+            fn to_f32(&self) -> Option<f32> {
+                impl_to_primitive_float_to_float!($T, f32, *self)
+            }
             #[inline]
-            fn to_f64(&self) -> Option<f64> { impl_to_primitive_float_to_float!($T, f64, *self) }
+            fn to_f64(&self) -> Option<f64> {
+                impl_to_primitive_float_to_float!($T, f64, *self)
+            }
         }
     )
 }
@@ -588,4 +646,18 @@ fn as_primitive() {
 
     let x: u8 = (768i16).as_();
     assert_eq!(x, 0);
+}
+
+#[test]
+fn float_to_integer_checks_overflow() {
+    // This will overflow an i32
+    let source: f64 = 1.0e+123f64;
+
+    // Expect the overflow to be caught
+    assert_eq!(source.to_i32(), None);
+
+    // Specifically make sure we didn't silently let the overflow through
+    // (This line is mostly for humans -- the robots should catch any problem
+    // on the line above).
+    assert_ne!(source.to_i32(), Some(-2147483648));
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -646,7 +646,7 @@ fn float_to_integer_checks_overflow() {
 }
 
 #[test]
-fn test_cast_to_int() {
+fn cast_to_int_checks_overflow() {
     let big_f: f64 = 1.0e123;
     let normal_f: f64 = 1.0;
     let small_f: f64 = -1.0e123;
@@ -670,7 +670,7 @@ fn test_cast_to_int() {
 }
 
 #[test]
-fn test_cast_to_unsigned_int() {
+fn cast_to_unsigned_int_checks_overflow() {
     let big_f: f64 = 1.0e123;
     let normal_f: f64 = 1.0;
     let small_f: f64 = -1.0e123;

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -654,5 +654,5 @@ fn float_to_integer_checks_overflow() {
     let source: f64 = 1.0e+123f64;
 
     // Expect the overflow to be caught
-    assert_eq!(source.to_i32(), None);
+    assert_eq!(cast::<f64, i32>(source), None);
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -238,17 +238,11 @@ macro_rules! impl_to_primitive_float_to_float {
 
 macro_rules! impl_to_primitive_float_to_signed_int {
     ($SrcT:ident, $DstT:ident, $slf:expr) => (
-        if size_of::<$SrcT>() <= size_of::<$DstT>() {
+        let t = $slf.trunc();
+        if t >= $DstT::MIN as $SrcT && t <= $DstT::MAX as $SrcT {
             Some($slf as $DstT)
         } else {
-            // Make sure the value is in range for the cast.
-            let n = $slf as $DstT;
-            let max_value: $DstT = ::std::$DstT::MAX;
-            if -max_value as $DstT <= n && n <= max_value as $DstT {
-                Some($slf as $DstT)
-            } else {
-                None
-            }
+            None
         }
     )
 }
@@ -655,4 +649,52 @@ fn float_to_integer_checks_overflow() {
 
     // Expect the overflow to be caught
     assert_eq!(cast::<f64, i32>(source), None);
+}
+
+#[test]
+fn test_cast_to_int() {
+    let big_f: f64 = 1.0e123;
+    let normal_f: f64 = 1.0;
+    let small_f: f64 = -1.0e123;
+    assert_eq!(None, cast::<f64, isize>(big_f));
+    assert_eq!(None, cast::<f64, i8>(big_f));
+    assert_eq!(None, cast::<f64, i16>(big_f));
+    assert_eq!(None, cast::<f64, i32>(big_f));
+    assert_eq!(None, cast::<f64, i64>(big_f));
+
+    assert_eq!(Some(normal_f as isize), cast::<f64, isize>(normal_f));
+    assert_eq!(Some(normal_f as i8), cast::<f64, i8>(normal_f));
+    assert_eq!(Some(normal_f as i16), cast::<f64, i16>(normal_f));
+    assert_eq!(Some(normal_f as i32), cast::<f64, i32>(normal_f));
+    assert_eq!(Some(normal_f as i64), cast::<f64, i64>(normal_f));
+
+    assert_eq!(None, cast::<f64, isize>(small_f));
+    assert_eq!(None, cast::<f64, i8>(small_f));
+    assert_eq!(None, cast::<f64, i16>(small_f));
+    assert_eq!(None, cast::<f64, i32>(small_f));
+    assert_eq!(None, cast::<f64, i64>(small_f));
+}
+
+#[test]
+fn test_cast_to_unsigned_int() {
+    let big_f: f64 = 1.0e123;
+    let normal_f: f64 = 1.0;
+    let small_f: f64 = -1.0e123;
+    assert_eq!(None, cast::<f64, usize>(big_f));
+    assert_eq!(None, cast::<f64, u8>(big_f));
+    assert_eq!(None, cast::<f64, u16>(big_f));
+    assert_eq!(None, cast::<f64, u32>(big_f));
+    assert_eq!(None, cast::<f64, u64>(big_f));
+
+    assert_eq!(Some(normal_f as usize), cast::<f64, usize>(normal_f));
+    assert_eq!(Some(normal_f as u8), cast::<f64, u8>(normal_f));
+    assert_eq!(Some(normal_f as u16), cast::<f64, u16>(normal_f));
+    assert_eq!(Some(normal_f as u32), cast::<f64, u32>(normal_f));
+    assert_eq!(Some(normal_f as u64), cast::<f64, u64>(normal_f));
+
+    assert_eq!(None, cast::<f64, usize>(small_f));
+    assert_eq!(None, cast::<f64, u8>(small_f));
+    assert_eq!(None, cast::<f64, u16>(small_f));
+    assert_eq!(None, cast::<f64, u32>(small_f));
+    assert_eq!(None, cast::<f64, u64>(small_f));
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -237,31 +237,25 @@ macro_rules! impl_to_primitive_float_to_float {
 }
 
 macro_rules! impl_to_primitive_float_to_signed_int {
-    ($SrcT:ident, $DstT:ident, $slf:expr) => (
+    ($SrcT:ident, $DstT:ident, $slf:expr) => ({
         let t = $slf.trunc();
-        if t >= $DstT::MIN as $SrcT && t <= $DstT::MAX as $SrcT {
+        if t >= $DstT::min_value() as $SrcT && t <= $DstT::max_value() as $SrcT {
             Some($slf as $DstT)
         } else {
             None
         }
-    )
+    })
 }
 
 macro_rules! impl_to_primitive_float_to_unsigned_int {
-    ($SrcT:ident, $DstT:ident, $slf:expr) => (
-        if size_of::<$SrcT>() <= size_of::<$DstT>() {
+    ($SrcT:ident, $DstT:ident, $slf:expr) => ({
+        let t = $slf.trunc();
+        if t >= $DstT::min_value() as $SrcT && t <= $DstT::max_value() as $SrcT {
             Some($slf as $DstT)
         } else {
-            // Make sure the value is in range for the cast.
-            let n = $slf as $DstT;
-            let max_value: $DstT = ::std::$DstT::MAX;
-            if n <= max_value as $DstT {
-                Some($slf as $DstT)
-            } else {
-                None
-            }
+            None
         }
-    )
+    })
 }
 
 macro_rules! impl_to_primitive_float {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -659,5 +659,5 @@ fn float_to_integer_checks_overflow() {
     // Specifically make sure we didn't silently let the overflow through
     // (This line is mostly for humans -- the robots should catch any problem
     // on the line above).
-    assert_ne!(source.to_i32(), Some(-2147483648));
+    assert!(source.to_i32() != Some(-2147483648));
 }


### PR DESCRIPTION
This change adds some new macro rules used when converting from floats
to integers. There are two macro rule variants, one for signed ints, one
for unsigned ints.

Among other things, this change specifically addresses the overflow case
documented in https://github.com/rust-num/num-traits/issues/12