### PR TITLE
Re-introduce the std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "algorithms", "science" ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-num/num-traits"
 name = "num-traits"
-version = "0.1.42"
+version = "0.2.0-pre"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ version = "0.1.42"
 readme = "README.md"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ and this to your crate root:
 extern crate num_traits;
 ```
 
+## Features
+
+This crate can be used without the standard library (`#![no_std]`) by disabling
+the default `std` feature.  Use this in `Cargo.toml`:
+
+```toml
+[dependencies.num-traits]
+version = "0.1"
+default-features = false
+```
+
+The `Float` and `Real` traits are only available when `std` is enabled.
+
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-traits = "0.1"
+num-traits = "0.2"
 ```
 
 and this to your crate root:
@@ -28,7 +28,7 @@ the default `std` feature.  Use this in `Cargo.toml`:
 
 ```toml
 [dependencies.num-traits]
-version = "0.1"
+version = "0.2"
 default-features = false
 ```
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -4,7 +4,7 @@ set -ex
 
 echo Testing num-traits on rustc ${TRAVIS_RUST_VERSION}
 
-# num-integer should build and test everywhere.
+# num-traits should build and test everywhere.
 cargo build --verbose
 cargo test --verbose
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -8,4 +8,6 @@ echo Testing num-traits on rustc ${TRAVIS_RUST_VERSION}
 cargo build --verbose
 cargo test --verbose
 
-# We have no features to test...
+# test `no_std`
+cargo build --verbose --no-default-features
+cargo test --verbose --no-default-features

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,7 +1,7 @@
-use std::{usize, u8, u16, u32, u64};
-use std::{isize, i8, i16, i32, i64};
-use std::{f32, f64};
-use std::num::Wrapping;
+use core::{usize, u8, u16, u32, u64};
+use core::{isize, i8, i16, i32, i64};
+use core::{f32, f64};
+use core::num::Wrapping;
 
 /// Numbers which have upper and lower bounds
 pub trait Bounded {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,9 +1,9 @@
+use core::f64;
 use core::mem::size_of;
 use core::num::Wrapping;
 
 use identities::Zero;
 use bounds::Bounded;
-use float::Float;
 
 /// A generic trait for converting a value to a number.
 pub trait ToPrimitive {
@@ -228,7 +228,9 @@ macro_rules! impl_to_primitive_float_to_float {
             // NaN and +-inf are cast as they are.
             let n = $slf as f64;
             let max_value: $DstT = ::core::$DstT::MAX;
-            if !Float::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
+            if n != n || n == f64::INFINITY || n == f64::NEG_INFINITY
+                || (-max_value as f64 <= n && n <= max_value as f64)
+            {
                 Some($slf as $DstT)
             } else {
                 None

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,8 +1,9 @@
-use std::mem::size_of;
-use std::num::Wrapping;
+use core::mem::size_of;
+use core::num::Wrapping;
 
 use identities::Zero;
 use bounds::Bounded;
+use float::Float;
 
 /// A generic trait for converting a value to a number.
 pub trait ToPrimitive {
@@ -226,8 +227,8 @@ macro_rules! impl_to_primitive_float_to_float {
             // Make sure the value is in range for the cast.
             // NaN and +-inf are cast as they are.
             let n = $slf as f64;
-            let max_value: $DstT = ::std::$DstT::MAX;
-            if !n.is_finite() || (-max_value as f64 <= n && n <= max_value as f64) {
+            let max_value: $DstT = ::core::$DstT::MAX;
+            if !Float::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
                 Some($slf as $DstT)
             } else {
                 None
@@ -522,8 +523,8 @@ impl_as_primitive!(bool => u8, i8, u16, i16, u32, i32, u64, isize, usize, i64);
 
 #[test]
 fn to_primitive_float() {
-    use std::f32;
-    use std::f64;
+    use core::f32;
+    use core::f64;
 
     let f32_toolarge = 1e39f64;
     assert_eq!(f32_toolarge.to_f32(), None);

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,15 +1,24 @@
+#[cfg(feature = "std")]
 use std::mem;
+#[cfg(feature = "std")]
 use std::ops::Neg;
+#[cfg(feature = "std")]
 use std::num::FpCategory;
 
 // Used for default implementation of `epsilon`
+#[cfg(feature = "std")]
 use std::f32;
 
+#[cfg(feature = "std")]
 use {Num, NumCast};
 
 // FIXME: these doctests aren't actually helpful, because they're using and
 // testing the inherent methods directly, not going through `Float`.
 
+/// Generic trait for floating point numbers
+///
+/// This trait is only available with the `std` feature.
+#[cfg(feature = "std")]
 pub trait Float
     : Num
     + Copy
@@ -923,6 +932,7 @@ pub trait Float
     fn integer_decode(self) -> (u64, i16, i8);
 }
 
+#[cfg(feature = "std")]
 macro_rules! float_impl {
     ($T:ident $decode:ident) => (
         impl Float for $T {
@@ -1219,6 +1229,7 @@ macro_rules! float_impl {
     )
 }
 
+#[cfg(feature = "std")]
 fn integer_decode_f32(f: f32) -> (u64, i16, i8) {
     let bits: u32 = unsafe { mem::transmute(f) };
     let sign: i8 = if bits >> 31 == 0 {
@@ -1237,6 +1248,7 @@ fn integer_decode_f32(f: f32) -> (u64, i16, i8) {
     (mantissa as u64, exponent, sign)
 }
 
+#[cfg(feature = "std")]
 fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     let bits: u64 = unsafe { mem::transmute(f) };
     let sign: i8 = if bits >> 63 == 0 {
@@ -1255,7 +1267,9 @@ fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     (mantissa, exponent, sign)
 }
 
+#[cfg(feature = "std")]
 float_impl!(f32 integer_decode_f32);
+#[cfg(feature = "std")]
 float_impl!(f64 integer_decode_f64);
 
 macro_rules! float_const_impl {
@@ -1272,7 +1286,7 @@ macro_rules! float_const_impl {
             $(
                 #[inline]
                 fn $constant() -> Self {
-                    ::std::$T::consts::$constant
+                    ::core::$T::consts::$constant
                 }
             )+
         }
@@ -1314,13 +1328,13 @@ float_const_impl! {
     SQRT_2,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use Float;
 
     #[test]
     fn convert_deg_rad() {
-        use std::f64::consts;
+        use core::f64::consts;
 
         const DEG_RAD_PAIRS: [(f64, f64); 7] = [
             (0.0, 0.),

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -1,5 +1,5 @@
-use std::ops::{Add, Mul};
-use std::num::Wrapping;
+use core::ops::{Add, Mul};
+use core::num::Wrapping;
 
 /// Defines an additive identity element for `Self`.
 pub trait Zero: Sized + Add<Self, Output = Self> {

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,4 +1,4 @@
-use std::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
+use core::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 
 use {Num, NumCast};
 use bounds::Bounded;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! Numeric traits for generic mathematics
 
-#![doc(html_root_url = "https://docs.rs/num-traits/0.1")]
+#![doc(html_root_url = "https://docs.rs/num-traits/0.2")]
 
 #![deny(unconditional_recursion)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,16 @@
 
 #![doc(html_root_url = "https://docs.rs/num-traits/0.1")]
 
-use std::ops::{Add, Sub, Mul, Div, Rem};
-use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
-use std::num::Wrapping;
-use std::fmt;
+#![deny(unconditional_recursion)]
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "std")]
+extern crate core;
+
+use core::ops::{Add, Sub, Mul, Div, Rem};
+use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
+use core::num::Wrapping;
+use core::fmt;
 
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
@@ -130,10 +136,10 @@ impl<T> NumAssignRef for T where T: NumAssign + for<'r> NumAssignOps<&'r T> {}
 macro_rules! int_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {
-            type FromStrRadixErr = ::std::num::ParseIntError;
+            type FromStrRadixErr = ::core::num::ParseIntError;
             #[inline]
             fn from_str_radix(s: &str, radix: u32)
-                              -> Result<Self, ::std::num::ParseIntError>
+                              -> Result<Self, ::core::num::ParseIntError>
             {
                 <$t>::from_str_radix(s, radix)
             }
@@ -159,7 +165,7 @@ pub enum FloatErrorKind {
     Empty,
     Invalid,
 }
-// FIXME: std::num::ParseFloatError is stable in 1.0, but opaque to us,
+// FIXME: core::num::ParseFloatError is stable in 1.0, but opaque to us,
 // so there's not really any way for us to reuse it.
 #[derive(Debug)]
 pub struct ParseFloatError {
@@ -317,8 +323,8 @@ macro_rules! float_trait_impl {
                         };
 
                         match (is_positive, exp) {
-                            (true,  Ok(exp)) => base.powi(exp as i32),
-                            (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
+                            (true,  Ok(exp)) => Float::powi(base, exp as i32),
+                            (false, Ok(exp)) => 1.0 / Float::powi(base, exp as i32),
                             (_, Err(_))      => return Err(PFE { kind: Invalid }),
                         }
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ pub use float::Float;
 pub use float::FloatConst;
 // pub use real::Real; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use identities::{Zero, One, zero, one};
-pub use ops::checked::*;
-pub use ops::wrapping::*;
+pub use ops::checked::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv, CheckedShl, CheckedShr};
+pub use ops::wrapping::{WrappingAdd, WrappingMul, WrappingSub};
 pub use ops::saturating::Saturating;
 pub use sign::{Signed, Unsigned, abs, abs_sub, signum};
-pub use cast::*;
+pub use cast::{AsPrimitive, FromPrimitive, ToPrimitive, NumCast, cast};
 pub use int::PrimInt;
 pub use pow::{pow, checked_pow};
 

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub, Mul, Div, Shl, Shr};
+use core::ops::{Add, Sub, Mul, Div, Shl, Shr};
 
 /// Performs addition that returns `None` instead of wrapping around on
 /// overflow.

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -1,5 +1,5 @@
-use std::ops::{Add, Sub, Mul};
-use std::num::Wrapping;
+use core::ops::{Add, Sub, Mul};
+use core::num::Wrapping;
 
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 use {One, CheckedMul};
 
 /// Raises a value to the power of exp, using exponentiation by squaring.

--- a/src/real.rs
+++ b/src/real.rs
@@ -10,6 +10,8 @@ use {Num, NumCast, Float};
 ///
 /// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
 /// for a list of data types that could meaningfully implement this trait.
+///
+/// This trait is only available with the `std` feature.
 pub trait Real
     : Num
     + Copy

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -2,7 +2,7 @@ use core::ops::Neg;
 use core::{f32, f64};
 use core::num::Wrapping;
 
-use {Num, Float};
+use Num;
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Sized + Num + Neg<Output = Self> {
@@ -103,8 +103,22 @@ macro_rules! signed_float_impl {
         impl Signed for $t {
             /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
             #[inline]
+            #[cfg(feature = "std")]
             fn abs(&self) -> $t {
                 (*self).abs()
+            }
+
+            /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
+            #[inline]
+            #[cfg(not(feature = "std"))]
+            fn abs(&self) -> $t {
+                if self.is_positive() {
+                    *self
+                } else if self.is_negative() {
+                    -*self
+                } else {
+                    $nan
+                }
             }
 
             /// The positive difference of two numbers. Returns `0.0` if the number is
@@ -121,8 +135,27 @@ macro_rules! signed_float_impl {
             /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
             /// - `NAN` if the number is NaN
             #[inline]
+            #[cfg(feature = "std")]
             fn signum(&self) -> $t {
+                use Float;
                 Float::signum(*self)
+            }
+
+            /// # Returns
+            ///
+            /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
+            /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
+            /// - `NAN` if the number is NaN
+            #[inline]
+            #[cfg(not(feature = "std"))]
+            fn signum(&self) -> $t {
+                if self.is_positive() {
+                    1.0
+                } else if self.is_negative() {
+                    -1.0
+                } else {
+                    $nan
+                }
             }
 
             /// Returns `true` if the number is positive, including `+0.0` and `INFINITY`

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,8 +1,8 @@
-use std::ops::Neg;
-use std::{f32, f64};
-use std::num::Wrapping;
+use core::ops::Neg;
+use core::{f32, f64};
+use core::num::Wrapping;
 
-use Num;
+use {Num, Float};
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Sized + Num + Neg<Output = Self> {
@@ -104,16 +104,15 @@ macro_rules! signed_float_impl {
             /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
             #[inline]
             fn abs(&self) -> $t {
-                <$t>::abs(*self)
+                (*self).abs()
             }
 
             /// The positive difference of two numbers. Returns `0.0` if the number is
             /// less than or equal to `other`, otherwise the difference between`self`
             /// and `other` is returned.
             #[inline]
-            #[allow(deprecated)]
             fn abs_sub(&self, other: &$t) -> $t {
-                <$t>::abs_sub(*self, *other)
+                if *self <= *other { 0. } else { *self - *other }
             }
 
             /// # Returns
@@ -123,7 +122,7 @@ macro_rules! signed_float_impl {
             /// - `NAN` if the number is NaN
             #[inline]
             fn signum(&self) -> $t {
-                <$t>::signum(*self)
+                Float::signum(*self)
             }
 
             /// Returns `true` if the number is positive, including `+0.0` and `INFINITY`


### PR DESCRIPTION
This is a port of @vks's rust-num/num#296, but without the feature-toggled changes to `Float`.  Now `Float` and the newer `Real` are completely dependent on having `std` enabled.  In the future we can consider adding separate more-limited float/real traits that can work without `std`, like the `BaseFloat` that was originally proposed in the former PR.

This is a breaking change with a bump to 0.2, since anyone currently using `default-features = false` will lose functionality.  The actual API is otherwise unchanged, so my plan is to employ the "semver trick" -- publishing a new num-traits-0.1 that re-exports everything from 0.2 (with `std`).  Thus all `num-traits` users should remain compatible even if they mix 0.1 and 0.2.

Closes #16.