### PR TITLE
Add is_one.

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -79,6 +79,14 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// `static mut`s.
     // FIXME (#5527): This should be an associated constant
     fn one() -> Self;
+
+    /// Returns `true` if `self` is equal to the multiplicative identity.
+    ///
+    /// Compatibility note: this method will be a requirement to implement in the future; new
+    /// implementors should provide it for future-compatibility.
+    fn is_one(&self) -> bool where Self: PartialEq {
+        *self == Self::one()
+    }
 }
 
 macro_rules! one_impl {

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -85,6 +85,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// For performance reasons, it's best to implement this manually.
     /// After a semver bump, this method will be required, and the
     /// `where Self: PartialEq` bound will be removed.
+    #[inline]
     fn is_one(&self) -> bool where Self: PartialEq {
         *self == Self::one()
     }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -82,8 +82,9 @@ pub trait One: Sized + Mul<Self, Output = Self> {
 
     /// Returns `true` if `self` is equal to the multiplicative identity.
     ///
-    /// Compatibility note: this method will be a requirement to implement in the future; new
-    /// implementors should provide it for future-compatibility.
+    /// For performance reasons, it's best to implement this manually.
+    /// After a semver bump, this method will be required, and the
+    /// `where Self: PartialEq` bound will be removed.
     fn is_one(&self) -> bool where Self: PartialEq {
         *self == Self::one()
     }


### PR DESCRIPTION
Implements the version recommended in #5. That issue should remain open to track the breaking-change version.