### PR TITLE
Add Default constraint to PrimInt

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -8,6 +8,7 @@ use ops::saturating::Saturating;
 pub trait PrimInt
     : Sized
     + Copy
+    + Default
     + Num + NumCast
     + Bounded
     + PartialOrd + Ord + Eq


### PR DESCRIPTION
I don't see any reason to intentionally leave off a `Default` trait bound, and it's useful to have. Note that this is technically a breaking change for anyone who has implemented `PrimInt` for their own types, so it should probably be part of `num-traits` 0.3 instead of 0.2.2.