### PR TITLE
Add Zero::is_nonzero.

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -23,6 +23,12 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// Returns `true` if `self` is equal to the additive identity.
     #[inline]
     fn is_zero(&self) -> bool;
+
+    /// Returns `true` if `self` is not equal to the additive identity.
+    #[inline]
+    fn is_nonzero(&self) -> bool {
+        !self.is_zero()
+    }
 }
 
 macro_rules! zero_impl {


### PR DESCRIPTION
Considering how this is a common use case, I figured that having a method for this might be reasonable. It can overridden to be faster in certain cases, but otherwise, it's just a convenience method.