### PR TITLE
Revive Float+Real in no_std thanks to libm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
         - rustup target add $TARGET
       script:
         - cargo build --verbose --target $TARGET --no-default-features --features i128
+        - cargo build --verbose --target $TARGET --no-default-features --features libm
     - name: "rustfmt"
       rust: 1.31.0
       before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["/ci/*", "/.travis.yml", "/bors.toml"]
 features = ["std"]
 
 [dependencies]
-libm = { version = "0.1", optional = true }
+libm = { version = "0.1.4", optional = true }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["/ci/*", "/.travis.yml", "/bors.toml"]
 features = ["std"]
 
 [dependencies]
+libm = { version = "~0.1.2", optional = true }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["/ci/*", "/.travis.yml", "/bors.toml"]
 features = ["std"]
 
 [dependencies]
-libm = { version = "~0.1.2", optional = true }
+libm = { version = "0.1", optional = true }
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ the default `std` feature. Use this in `Cargo.toml`:
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
+# features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real`
 ```
 
-The `Float` and `Real` traits are only available when `std` is enabled. The
-`FloatCore` trait is always available.  `MulAdd` and `MulAddAssign` for `f32`
+The `Float` and `Real` traits are only available when either `std` or `libm` is enabled.
+
+The `FloatCore` trait is always available.  `MulAdd` and `MulAddAssign` for `f32`
 and `f64` also require `std`, as do implementations of signed and floating-
 point exponents in `Pow`.
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ the default `std` feature. Use this in `Cargo.toml`:
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
-# features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real`
+# features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real` without `std`
 ```
 
 The `Float` and `Real` traits are only available when either `std` or `libm` is enabled.
 
 The `FloatCore` trait is always available.  `MulAdd` and `MulAddAssign` for `f32`
-and `f64` also require `std`, as do implementations of signed and floating-
+and `f64` also require `std` or `libm`, as do implementations of signed and floating-
 point exponents in `Pow`.
 
 Implementations for `i128` and `u128` are only available with Rust 1.26 and

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ default-features = false
 ```
 
 The `Float` and `Real` traits are only available when either `std` or `libm` is enabled.  
-The `libm` feature is only available with Rust 1.31 and later.
+The `libm` feature is only available with Rust 1.31 and later ([see PR #99](https://github.com/rust-num/num-traits/pull/99)).
 
 The `FloatCore` trait is always available.  `MulAdd` and `MulAddAssign` for `f32`
 and `f64` also require `std` or `libm`, as do implementations of signed and floating-

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ default-features = false
 # features = ["libm"]    # <--- Uncomment if you wish to use `Float` and `Real` without `std`
 ```
 
-The `Float` and `Real` traits are only available when either `std` or `libm` is enabled.
+The `Float` and `Real` traits are only available when either `std` or `libm` is enabled.  
+The `libm` feature is only available with Rust 1.31 and later.
 
 The `FloatCore` trait is always available.  `MulAdd` and `MulAddAssign` for `f32`
 and `f64` also require `std` or `libm`, as do implementations of signed and floating-

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -8,21 +8,20 @@ echo Testing num-traits on rustc ${TRAVIS_RUST_VERSION}
 cargo build --verbose
 cargo test --verbose
 
-# test with std and libm
-cargo build --verbose --features "libm"
-cargo test --verbose --features "libm"
-
 # test `no_std`
 cargo build --verbose --no-default-features
 cargo test --verbose --no-default-features
 
-# test `no_std` with libm
-cargo build --verbose --no-default-features --features "libm"
-cargo test --verbose --no-default-features --features "libm"
-
-
-# test `i128`
 if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then
+    # test `i128`
     cargo build --verbose --features=i128
     cargo test --verbose --features=i128
+
+    # test with std and libm (libm build fails on Rust 1.26 and earlier)
+    cargo build --verbose --features "libm"
+    cargo test --verbose --features "libm"
+
+    # test `no_std` with libm (libm build fails on Rust 1.26 and earlier)
+    cargo build --verbose --no-default-features --features "libm"
+    cargo test --verbose --no-default-features --features "libm"
 fi

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -8,9 +8,18 @@ echo Testing num-traits on rustc ${TRAVIS_RUST_VERSION}
 cargo build --verbose
 cargo test --verbose
 
+# test with std and libm
+cargo build --verbose --features "libm"
+cargo test --verbose --features "libm"
+
 # test `no_std`
 cargo build --verbose --no-default-features
 cargo test --verbose --no-default-features
+
+# test `no_std` with libm
+cargo build --verbose --no-default-features --features "libm"
+cargo test --verbose --no-default-features --features "libm"
+
 
 # test `i128`
 if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then

--- a/src/float.rs
+++ b/src/float.rs
@@ -7,7 +7,7 @@ use core::f64;
 
 use {Num, NumCast, ToPrimitive};
 
-#[cfg(feature = "libm")]
+#[cfg(all(not(feature = "std"), feature = "libm"))]
 use libm::{F32Ext, F64Ext};
 
 /// Generic trait for floating point numbers that works with `no_std`.
@@ -1887,7 +1887,7 @@ macro_rules! float_impl_std {
     };
 }
 
-#[cfg(feature = "libm")]
+#[cfg(all(not(feature = "std"), feature = "libm"))]
 macro_rules! float_impl_libm {
     ($T:ident $decode:ident $LibmImpl:ident) => {
         impl Float for $T {

--- a/src/float.rs
+++ b/src/float.rs
@@ -10,7 +10,6 @@ use {Num, NumCast, ToPrimitive};
 #[cfg(feature = "libm")]
 use libm::{F32Ext, F64Ext};
 
-
 /// Generic trait for floating point numbers that works with `no_std`.
 ///
 /// This trait implements a subset of the `Float` trait.
@@ -1835,7 +1834,7 @@ macro_rules! float_impl_std {
                 $decode(self)
             }
 
-            forward!{
+            forward! {
                 Self::is_nan(self) -> bool;
                 Self::is_infinite(self) -> bool;
                 Self::is_finite(self) -> bool;
@@ -1914,7 +1913,7 @@ macro_rules! float_impl_libm {
                 $decode(self)
             }
 
-            forward!{
+            forward! {
                 FloatCore::is_nan(self) -> bool;
                 FloatCore::is_infinite(self) -> bool;
                 FloatCore::is_finite(self) -> bool;
@@ -2008,7 +2007,6 @@ float_impl_std!(f64 integer_decode_f64);
 float_impl_libm!(f32 integer_decode_f32 F32Ext);
 #[cfg(all(not(feature = "std"), feature = "libm"))]
 float_impl_libm!(f64 integer_decode_f64 F64Ext);
-
 
 macro_rules! float_const_impl {
     ($(#[$doc:meta] $constant:ident,)+) => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,16 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "libm")]
+extern crate libm;
+
 use core::fmt;
 use core::num::Wrapping;
 use core::ops::{Add, Div, Mul, Rem, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
 pub use bounds::Bounded;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 pub use float::Float;
 pub use float::FloatConst;
 // pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
@@ -53,7 +56,7 @@ pub mod identities;
 pub mod int;
 pub mod ops;
 pub mod pow;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 pub mod real;
 pub mod sign;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ pub mod identities;
 pub mod int;
 pub mod ops;
 pub mod pow;
-#[cfg(any(feature = "std", feature = "libm"))]
 pub mod real;
 pub mod sign;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "libm")]
+// Only `no_std` builds actually use `libm`.
+#[cfg(all(not(feature = "std"), feature = "libm"))]
 extern crate libm;
 
 use core::fmt;

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -34,46 +34,25 @@ pub trait MulAddAssign<A = Self, B = Self> {
     fn mul_add_assign(&mut self, a: A, b: B);
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MulAdd<f32, f32> for f32 {
     type Output = Self;
 
     #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self::Output {
-        f32::mul_add(self, a, b)
+        <Self as ::Float>::mul_add(self, a, b)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MulAdd<f64, f64> for f64 {
     type Output = Self;
 
     #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self::Output {
-        f64::mul_add(self, a, b)
+        <Self as ::Float>::mul_add(self, a, b)
     }
 }
-
-#[cfg(all(not(feature = "std"), feature = "libm"))]
-impl MulAdd<f32, f32> for f32 {
-    type Output = Self;
-
-    #[inline]
-    fn mul_add(self, a: Self, b: Self) -> Self::Output {
-        <f32 as ::libm::F32Ext>::mul_add(self, a, b)
-    }
-}
-
-#[cfg(all(not(feature = "std"), feature = "libm"))]
-impl MulAdd<f64, f64> for f64 {
-    type Output = Self;
-
-    #[inline]
-    fn mul_add(self, a: Self, b: Self) -> Self::Output {
-        <f64 as ::libm::F64Ext>::mul_add(self, a, b)
-    }
-}
-
 
 macro_rules! mul_add_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
@@ -92,38 +71,21 @@ mul_add_impl!(MulAdd for isize usize i8 u8 i16 u16 i32 u32 i64 u64);
 #[cfg(has_i128)]
 mul_add_impl!(MulAdd for i128 u128);
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MulAddAssign<f32, f32> for f32 {
     #[inline]
     fn mul_add_assign(&mut self, a: Self, b: Self) {
-        *self = f32::mul_add(*self, a, b)
+        *self = <Self as ::Float>::mul_add(*self, a, b)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MulAddAssign<f64, f64> for f64 {
     #[inline]
     fn mul_add_assign(&mut self, a: Self, b: Self) {
-        *self = f64::mul_add(*self, a, b)
+        *self = <Self as ::Float>::mul_add(*self, a, b)
     }
 }
-
-#[cfg(all(not(feature = "std"), feature = "libm"))]
-impl MulAddAssign<f32, f32> for f32 {
-    #[inline]
-    fn mul_add_assign(&mut self, a: Self, b: Self) {
-        *self = <f32 as ::libm::F32Ext>::mul_add(*self, a, b)
-    }
-}
-
-#[cfg(all(not(feature = "std"), feature = "libm"))]
-impl MulAddAssign<f64, f64> for f64 {
-    #[inline]
-    fn mul_add_assign(&mut self, a: Self, b: Self) {
-        *self = <f64 as ::libm::F64Ext>::mul_add(*self, a, b)
-    }
-}
-
 
 macro_rules! mul_add_assign_impl {
     ($trait_name:ident for $($t:ty)*) => {$(

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -54,6 +54,27 @@ impl MulAdd<f64, f64> for f64 {
     }
 }
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+impl MulAdd<f32, f32> for f32 {
+    type Output = Self;
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self::Output {
+        <f32 as ::libm::F32Ext>::mul_add(self, a, b)
+    }
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+impl MulAdd<f64, f64> for f64 {
+    type Output = Self;
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self::Output {
+        <f64 as ::libm::F64Ext>::mul_add(self, a, b)
+    }
+}
+
+
 macro_rules! mul_add_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         impl $trait_name for $t {
@@ -86,6 +107,23 @@ impl MulAddAssign<f64, f64> for f64 {
         *self = f64::mul_add(*self, a, b)
     }
 }
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+impl MulAddAssign<f32, f32> for f32 {
+    #[inline]
+    fn mul_add_assign(&mut self, a: Self, b: Self) {
+        *self = <f32 as ::libm::F32Ext>::mul_add(*self, a, b)
+    }
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+impl MulAddAssign<f64, f64> for f64 {
+    #[inline]
+    fn mul_add_assign(&mut self, a: Self, b: Self) {
+        *self = <f64 as ::libm::F64Ext>::mul_add(*self, a, b)
+    }
+}
+
 
 macro_rules! mul_add_assign_impl {
     ($trait_name:ident for $($t:ty)*) => {$(

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -155,15 +155,15 @@ pow_impl!(Wrapping<isize>);
 #[cfg(any(feature = "std", feature = "libm"))]
 mod float_impls {
     use super::Pow;
-    use ::Float;
+    use Float;
 
-    pow_impl!(f32, i8, i32,  <f32 as Float>::powi);
-    pow_impl!(f32, u8, i32,  <f32 as Float>::powi);
+    pow_impl!(f32, i8, i32, <f32 as Float>::powi);
+    pow_impl!(f32, u8, i32, <f32 as Float>::powi);
     pow_impl!(f32, i16, i32, <f32 as Float>::powi);
     pow_impl!(f32, u16, i32, <f32 as Float>::powi);
     pow_impl!(f32, i32, i32, <f32 as Float>::powi);
-    pow_impl!(f64, i8, i32,  <f64 as Float>::powi);
-    pow_impl!(f64, u8, i32,  <f64 as Float>::powi);
+    pow_impl!(f64, i8, i32, <f64 as Float>::powi);
+    pow_impl!(f64, u8, i32, <f64 as Float>::powi);
     pow_impl!(f64, i16, i32, <f64 as Float>::powi);
     pow_impl!(f64, u16, i32, <f64 as Float>::powi);
     pow_impl!(f64, i32, i32, <f64 as Float>::powi);

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -152,23 +152,24 @@ pow_impl!(Wrapping<isize>);
 // pow_impl!(usize, u64);
 // pow_impl!(isize, u64);
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 mod float_impls {
     use super::Pow;
+    use ::Float;
 
-    pow_impl!(f32, i8, i32, f32::powi);
-    pow_impl!(f32, u8, i32, f32::powi);
-    pow_impl!(f32, i16, i32, f32::powi);
-    pow_impl!(f32, u16, i32, f32::powi);
-    pow_impl!(f32, i32, i32, f32::powi);
-    pow_impl!(f64, i8, i32, f64::powi);
-    pow_impl!(f64, u8, i32, f64::powi);
-    pow_impl!(f64, i16, i32, f64::powi);
-    pow_impl!(f64, u16, i32, f64::powi);
-    pow_impl!(f64, i32, i32, f64::powi);
-    pow_impl!(f32, f32, f32, f32::powf);
-    pow_impl!(f64, f32, f64, f64::powf);
-    pow_impl!(f64, f64, f64, f64::powf);
+    pow_impl!(f32, i8, i32,  <f32 as Float>::powi);
+    pow_impl!(f32, u8, i32,  <f32 as Float>::powi);
+    pow_impl!(f32, i16, i32, <f32 as Float>::powi);
+    pow_impl!(f32, u16, i32, <f32 as Float>::powi);
+    pow_impl!(f32, i32, i32, <f32 as Float>::powi);
+    pow_impl!(f64, i8, i32,  <f64 as Float>::powi);
+    pow_impl!(f64, u8, i32,  <f64 as Float>::powi);
+    pow_impl!(f64, i16, i32, <f64 as Float>::powi);
+    pow_impl!(f64, u16, i32, <f64 as Float>::powi);
+    pow_impl!(f64, i32, i32, <f64 as Float>::powi);
+    pow_impl!(f32, f32, f32, <f32 as Float>::powf);
+    pow_impl!(f64, f32, f64, <f64 as Float>::powf);
+    pow_impl!(f64, f64, f64, <f64 as Float>::powf);
 }
 
 /// Raises a value to the power of exp, using exponentiation by squaring.

--- a/src/real.rs
+++ b/src/real.rs
@@ -1,9 +1,8 @@
+#![cfg(any(feature = "std", feature = "libm"))]
+
 use core::ops::Neg;
 
-use {Num, NumCast};
-
-#[cfg(any(feature = "std", feature = "libm"))]
-use Float;
+use {Float, Num, NumCast};
 
 // NOTE: These doctests have the same issue as those in src/float.rs.
 // They're testing the inherent methods directly, and not those of `Real`.
@@ -14,14 +13,11 @@ use Float;
 /// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
 /// for a list of data types that could meaningfully implement this trait.
 ///
-/// This trait is always available, however it requires either `std` or `libm`
-/// in order for `f32` and `f64` to implement it.
-#[cfg(any(feature = "std", feature = "libm"))]
+/// This trait is only available with the `std` feature, or with the `libm` feature otherwise.
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -33,8 +29,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -46,8 +41,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns epsilon, a small positive value.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -64,8 +58,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -76,8 +69,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest integer less than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
@@ -90,8 +82,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest integer greater than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
@@ -105,8 +96,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the nearest integer to a number. Round half-way cases away from
     /// `0.0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -119,8 +109,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Return the integer part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -133,8 +122,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the fractional part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
@@ -150,8 +138,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the absolute value of `self`. Returns `Float::nan()` if the
     /// number is `Float::nan()`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -174,8 +161,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -191,8 +177,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is positive, including `+0.0`,
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -210,8 +195,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is negative, including `-0.0`,
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -232,8 +216,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using `mul_add` can be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
@@ -249,8 +232,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -264,8 +246,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// Using this function is generally faster than using `powf`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -277,8 +258,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Raise a number to a real number power.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -296,8 +276,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
@@ -312,8 +291,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `e^(self)`, (the exponential function).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -329,8 +307,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `2^(self)`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
@@ -348,8 +325,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -369,8 +345,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -393,8 +368,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
@@ -413,8 +387,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -428,8 +401,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts radians to degrees.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -442,8 +414,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts degrees to radians.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use std::f64::consts;
     ///
     /// let angle = 180.0_f64;
@@ -456,8 +427,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the maximum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -469,8 +439,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the minimum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -485,8 +454,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * If `self <= other`: `0:0`
     /// * Else: `self - other`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
@@ -502,8 +470,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the cubic root of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
@@ -518,8 +485,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Calculate the length of the hypotenuse of a right-angle triangle given
     /// legs of length `x` and `y`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -534,8 +500,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the sine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -549,8 +514,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the cosine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -564,8 +528,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the tangent of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -585,8 +548,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -608,8 +570,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -625,8 +586,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the arctangent of a number. Return value is in radians in the
     /// range [-pi/2, pi/2];
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
@@ -645,8 +605,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -671,8 +630,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
     /// `(sin(x), cos(x))`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -690,8 +648,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `e^(self) - 1` in a way that is accurate even if the
     /// number is close to zero.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
@@ -711,8 +668,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if `self-1 <= 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -727,8 +683,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -746,8 +701,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -765,8 +719,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -784,8 +737,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -799,8 +751,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -814,8 +765,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
+    /// ```
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -829,7 +779,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     fn atanh(self) -> Self;
 }
 
-#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float> Real for T {
     forward! {
         Float::min_value() -> Self;

--- a/src/real.rs
+++ b/src/real.rs
@@ -16,6 +16,7 @@ use Float;
 ///
 /// This trait is always available, however it requires either `std` or `libm`
 /// in order for `f32` and `f64` to implement it.
+#[cfg(any(feature = "std", feature = "libm"))]
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///

--- a/src/real.rs
+++ b/src/real.rs
@@ -1,6 +1,9 @@
 use core::ops::Neg;
 
-use {Float, Num, NumCast};
+use {Num, NumCast};
+
+#[cfg(any(feature = "std", feature = "libm"))]
+use Float;
 
 // NOTE: These doctests have the same issue as those in src/float.rs.
 // They're testing the inherent methods directly, and not those of `Real`.
@@ -777,6 +780,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     fn atanh(self) -> Self;
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float> Real for T {
     forward! {
         Float::min_value() -> Self;

--- a/src/real.rs
+++ b/src/real.rs
@@ -14,48 +14,45 @@ use Float;
 /// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
 /// for a list of data types that could meaningfully implement this trait.
 ///
-/// This trait is only available with the `std` feature, or with the `libm` feature otherwise.
-#[doc(test(attr(cfg(any(feature = "std", feature = "libm")))))]
+/// This trait is always available, however it requires either `std` or `libm`
+/// in order for `f32` and `f64` to implement it.
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_value();
     ///
     /// assert_eq!(x, f64::MIN);
-    /// # }
     /// ```
     fn min_value() -> Self;
 
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_positive_value();
     ///
     /// assert_eq!(x, f64::MIN_POSITIVE);
-    /// # }
     /// ```
     fn min_positive_value() -> Self;
 
     /// Returns epsilon, a small positive value.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::epsilon();
     ///
     /// assert_eq!(x, f64::EPSILON);
-    /// # }
     /// ```
     ///
     /// # Panics
@@ -66,21 +63,20 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest finite value that this type can represent.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::max_value();
     /// assert_eq!(x, f64::MAX);
-    /// # }
     /// ```
     fn max_value() -> Self;
 
     /// Returns the largest integer less than or equal to a number.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
@@ -88,14 +84,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.floor(), 3.0);
     /// assert_eq!(g.floor(), 3.0);
-    /// # }
     /// ```
     fn floor(self) -> Self;
 
     /// Returns the smallest integer greater than or equal to a number.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
@@ -103,15 +98,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
-    /// # }
     /// ```
     fn ceil(self) -> Self;
 
     /// Returns the nearest integer to a number. Round half-way cases away from
     /// `0.0`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -119,14 +113,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
-    /// # }
     /// ```
     fn round(self) -> Self;
 
     /// Return the integer part of a number.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -134,14 +127,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.trunc(), 3.0);
     /// assert_eq!(g.trunc(), -3.0);
-    /// # }
     /// ```
     fn trunc(self) -> Self;
 
     /// Returns the fractional part of a number.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
@@ -151,15 +143,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
-    /// # }
     /// ```
     fn fract(self) -> Self;
 
     /// Computes the absolute value of `self`. Returns `Float::nan()` if the
     /// number is `Float::nan()`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -173,7 +164,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(abs_difference_y < 1e-10);
     ///
     /// assert!(::num_traits::Float::is_nan(f64::NAN.abs()));
-    /// # }
     /// ```
     fn abs(self) -> Self;
 
@@ -183,8 +173,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -194,15 +184,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert_eq!(f64::NEG_INFINITY.signum(), -1.0);
     ///
     /// assert!(f64::NAN.signum().is_nan());
-    /// # }
     /// ```
     fn signum(self) -> Self;
 
     /// Returns `true` if `self` is positive, including `+0.0`,
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -214,15 +203,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
     /// assert!(!neg_nan.is_sign_positive());
-    /// # }
     /// ```
     fn is_sign_positive(self) -> bool;
 
     /// Returns `true` if `self` is negative, including `-0.0`,
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -234,7 +222,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
     /// assert!(!nan.is_sign_negative());
-    /// # }
     /// ```
     fn is_sign_negative(self) -> bool;
 
@@ -244,8 +231,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using `mul_add` can be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
@@ -256,21 +243,19 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (m.mul_add(x, b) - (m*x + b)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn mul_add(self, a: Self, b: Self) -> Self;
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn recip(self) -> Self;
 
@@ -278,29 +263,27 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// Using this function is generally faster than using `powf`
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn powi(self, n: i32) -> Self;
 
     /// Raise a number to a real number power.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn powf(self, n: Self) -> Self;
 
@@ -312,8 +295,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
@@ -323,14 +306,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference < 1e-10);
     /// assert!(::num_traits::Float::is_nan(negative.sqrt()));
-    /// # }
     /// ```
     fn sqrt(self) -> Self;
 
     /// Returns `e^(self)`, (the exponential function).
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -341,14 +323,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn exp(self) -> Self;
 
     /// Returns `2^(self)`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
@@ -357,7 +338,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn exp2(self) -> Self;
 
@@ -367,8 +347,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -379,7 +359,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn ln(self) -> Self;
 
@@ -389,8 +368,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -404,7 +383,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_10 < 1e-10);
     /// assert!(abs_difference_2 < 1e-10);
-    /// # }
     /// ```
     fn log(self, base: Self) -> Self;
 
@@ -414,8 +392,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
@@ -424,7 +402,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn log2(self) -> Self;
 
@@ -435,8 +412,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -445,14 +422,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn log10(self) -> Self;
 
     /// Converts radians to degrees.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -460,14 +436,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn to_degrees(self) -> Self;
 
     /// Converts degrees to radians.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = 180.0_f64;
@@ -475,35 +450,32 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (angle.to_radians() - consts::PI).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn to_radians(self) -> Self;
 
     /// Returns the maximum of the two numbers.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
     ///
     /// assert_eq!(x.max(y), y);
-    /// # }
     /// ```
     fn max(self, other: Self) -> Self;
 
     /// Returns the minimum of the two numbers.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
     ///
     /// assert_eq!(x.min(y), x);
-    /// # }
     /// ```
     fn min(self, other: Self) -> Self;
 
@@ -512,8 +484,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * If `self <= other`: `0:0`
     /// * Else: `self - other`
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
@@ -524,14 +496,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
-    /// # }
     /// ```
     fn abs_sub(self, other: Self) -> Self;
 
     /// Take the cubic root of a number.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
@@ -540,15 +511,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.cbrt() - 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn cbrt(self) -> Self;
 
     /// Calculate the length of the hypotenuse of a right-angle triangle given
     /// legs of length `x` and `y`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -558,14 +528,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn hypot(self, other: Self) -> Self;
 
     /// Computes the sine of a number (in radians).
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -574,14 +543,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn sin(self) -> Self;
 
     /// Computes the cosine of a number (in radians).
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -590,14 +558,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn cos(self) -> Self;
 
     /// Computes the tangent of a number (in radians).
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -605,7 +572,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.tan() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-14);
-    /// # }
     /// ```
     fn tan(self) -> Self;
 
@@ -618,8 +584,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -629,7 +595,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.sin().asin() - f64::consts::PI / 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn asin(self) -> Self;
 
@@ -642,8 +607,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -653,15 +618,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.cos().acos() - f64::consts::PI / 4.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn acos(self) -> Self;
 
     /// Computes the arctangent of a number. Return value is in radians in the
     /// range [-pi/2, pi/2];
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
@@ -670,7 +634,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.tan().atan() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn atan(self) -> Self;
 
@@ -681,8 +644,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -701,15 +664,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_1 < 1e-10);
     /// assert!(abs_difference_2 < 1e-10);
-    /// # }
     /// ```
     fn atan2(self, other: Self) -> Self;
 
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
     /// `(sin(x), cos(x))`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -721,15 +683,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_0 < 1e-10);
     /// assert!(abs_difference_0 < 1e-10);
-    /// # }
     /// ```
     fn sin_cos(self) -> (Self, Self);
 
     /// Returns `e^(self) - 1` in a way that is accurate even if the
     /// number is close to zero.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
@@ -738,7 +699,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.ln().exp_m1() - 6.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn exp_m1(self) -> Self;
 
@@ -750,8 +710,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if `self-1 <= 0`.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -761,14 +721,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.ln_1p() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn ln_1p(self) -> Self;
 
     /// Hyperbolic sine function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -781,14 +740,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - g).abs();
     ///
     /// assert!(abs_difference < 1e-10);
-    /// # }
     /// ```
     fn sinh(self) -> Self;
 
     /// Hyperbolic cosine function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -801,14 +759,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// // Same result
     /// assert!(abs_difference < 1.0e-10);
-    /// # }
     /// ```
     fn cosh(self) -> Self;
 
     /// Hyperbolic tangent function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -821,14 +778,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - g).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
-    /// # }
     /// ```
     fn tanh(self) -> Self;
 
     /// Inverse hyperbolic sine function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -837,14 +793,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - x).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
-    /// # }
     /// ```
     fn asinh(self) -> Self;
 
     /// Inverse hyperbolic cosine function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -853,14 +808,13 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - x).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
-    /// # }
     /// ```
     fn acosh(self) -> Self;
 
     /// Inverse hyperbolic tangent function.
     ///
-    /// ```
-    /// # #[cfg(any(feature = "std", feature = "libm"))] {
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -870,7 +824,6 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - e).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
-    /// # }
     /// ```
     fn atanh(self) -> Self;
 }

--- a/src/real.rs
+++ b/src/real.rs
@@ -19,8 +19,8 @@ use Float;
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -32,8 +32,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -45,8 +45,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns epsilon, a small positive value.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -63,8 +63,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -75,8 +75,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest integer less than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
@@ -89,8 +89,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest integer greater than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
@@ -104,8 +104,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the nearest integer to a number. Round half-way cases away from
     /// `0.0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -118,8 +118,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Return the integer part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -132,8 +132,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the fractional part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
@@ -149,8 +149,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the absolute value of `self`. Returns `Float::nan()` if the
     /// number is `Float::nan()`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -173,8 +173,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -190,8 +190,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is positive, including `+0.0`,
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -209,8 +209,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is negative, including `-0.0`,
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -231,8 +231,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using `mul_add` can be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
@@ -248,8 +248,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -263,8 +263,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// Using this function is generally faster than using `powf`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -276,8 +276,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Raise a number to a real number power.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -295,8 +295,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
@@ -311,8 +311,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `e^(self)`, (the exponential function).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -328,8 +328,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `2^(self)`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
@@ -347,8 +347,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -368,8 +368,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -392,8 +392,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
@@ -412,8 +412,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -427,8 +427,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts radians to degrees.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -441,8 +441,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts degrees to radians.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = 180.0_f64;
@@ -455,8 +455,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the maximum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -468,8 +468,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the minimum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -484,8 +484,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * If `self <= other`: `0:0`
     /// * Else: `self - other`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
@@ -501,8 +501,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the cubic root of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
@@ -517,8 +517,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Calculate the length of the hypotenuse of a right-angle triangle given
     /// legs of length `x` and `y`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -533,8 +533,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the sine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -548,8 +548,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the cosine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -563,8 +563,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the tangent of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -584,8 +584,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -607,8 +607,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -624,8 +624,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the arctangent of a number. Return value is in radians in the
     /// range [-pi/2, pi/2];
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
@@ -644,8 +644,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -670,8 +670,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
     /// `(sin(x), cos(x))`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -689,8 +689,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `e^(self) - 1` in a way that is accurate even if the
     /// number is close to zero.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
@@ -710,8 +710,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if `self-1 <= 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -726,8 +726,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -745,8 +745,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -764,8 +764,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -783,8 +783,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -798,8 +798,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -813,8 +813,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc="```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc="```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///

--- a/src/real.rs
+++ b/src/real.rs
@@ -15,40 +15,47 @@ use Float;
 /// for a list of data types that could meaningfully implement this trait.
 ///
 /// This trait is only available with the `std` feature, or with the `libm` feature otherwise.
+#[doc(test(attr(cfg(any(feature = "std", feature = "libm")))))]
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_value();
     ///
     /// assert_eq!(x, f64::MIN);
+    /// # }
     /// ```
     fn min_value() -> Self;
 
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::min_positive_value();
     ///
     /// assert_eq!(x, f64::MIN_POSITIVE);
+    /// # }
     /// ```
     fn min_positive_value() -> Self;
 
     /// Returns epsilon, a small positive value.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::epsilon();
     ///
     /// assert_eq!(x, f64::EPSILON);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -60,17 +67,20 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
     /// let x: f64 = Real::max_value();
     /// assert_eq!(x, f64::MAX);
+    /// # }
     /// ```
     fn max_value() -> Self;
 
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
@@ -78,12 +88,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.floor(), 3.0);
     /// assert_eq!(g.floor(), 3.0);
+    /// # }
     /// ```
     fn floor(self) -> Self;
 
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
@@ -91,6 +103,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
+    /// # }
     /// ```
     fn ceil(self) -> Self;
 
@@ -98,6 +111,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `0.0`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -105,12 +119,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
+    /// # }
     /// ```
     fn round(self) -> Self;
 
     /// Return the integer part of a number.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -118,12 +134,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert_eq!(f.trunc(), 3.0);
     /// assert_eq!(g.trunc(), -3.0);
+    /// # }
     /// ```
     fn trunc(self) -> Self;
 
     /// Returns the fractional part of a number.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
@@ -133,6 +151,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
+    /// # }
     /// ```
     fn fract(self) -> Self;
 
@@ -140,6 +159,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is `Float::nan()`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -153,6 +173,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(abs_difference_y < 1e-10);
     ///
     /// assert!(::num_traits::Float::is_nan(f64::NAN.abs()));
+    /// # }
     /// ```
     fn abs(self) -> Self;
 
@@ -163,6 +184,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -172,6 +194,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert_eq!(f64::NEG_INFINITY.signum(), -1.0);
     ///
     /// assert!(f64::NAN.signum().is_nan());
+    /// # }
     /// ```
     fn signum(self) -> Self;
 
@@ -179,6 +202,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -190,6 +214,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
     /// assert!(!neg_nan.is_sign_positive());
+    /// # }
     /// ```
     fn is_sign_positive(self) -> bool;
 
@@ -197,6 +222,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -208,6 +234,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
     /// assert!(!nan.is_sign_negative());
+    /// # }
     /// ```
     fn is_sign_negative(self) -> bool;
 
@@ -218,6 +245,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
@@ -228,18 +256,21 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (m.mul_add(x, b) - (m*x + b)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn mul_add(self, a: Self, b: Self) -> Self;
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn recip(self) -> Self;
 
@@ -248,24 +279,28 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powi(2) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn powi(self, n: i32) -> Self;
 
     /// Raise a number to a real number power.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn powf(self, n: Self) -> Self;
 
@@ -278,6 +313,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
@@ -287,12 +323,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference < 1e-10);
     /// assert!(::num_traits::Float::is_nan(negative.sqrt()));
+    /// # }
     /// ```
     fn sqrt(self) -> Self;
 
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -303,12 +341,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn exp(self) -> Self;
 
     /// Returns `2^(self)`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
@@ -317,6 +357,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn exp2(self) -> Self;
 
@@ -327,6 +368,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -337,6 +379,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn ln(self) -> Self;
 
@@ -347,6 +390,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -360,6 +404,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_10 < 1e-10);
     /// assert!(abs_difference_2 < 1e-10);
+    /// # }
     /// ```
     fn log(self, base: Self) -> Self;
 
@@ -370,6 +415,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
@@ -378,6 +424,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn log2(self) -> Self;
 
@@ -389,6 +436,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -397,12 +445,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn log10(self) -> Self;
 
     /// Converts radians to degrees.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -410,12 +460,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn to_degrees(self) -> Self;
 
     /// Converts degrees to radians.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use std::f64::consts;
     ///
     /// let angle = 180.0_f64;
@@ -423,30 +475,35 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (angle.to_radians() - consts::PI).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn to_radians(self) -> Self;
 
     /// Returns the maximum of the two numbers.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
     ///
     /// assert_eq!(x.max(y), y);
+    /// # }
     /// ```
     fn max(self, other: Self) -> Self;
 
     /// Returns the minimum of the two numbers.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
     /// let y = 2.0;
     ///
     /// assert_eq!(x.min(y), x);
+    /// # }
     /// ```
     fn min(self, other: Self) -> Self;
 
@@ -456,6 +513,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * Else: `self - other`
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
@@ -466,12 +524,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
+    /// # }
     /// ```
     fn abs_sub(self, other: Self) -> Self;
 
     /// Take the cubic root of a number.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
@@ -480,6 +540,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.cbrt() - 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn cbrt(self) -> Self;
 
@@ -487,6 +548,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// legs of length `x` and `y`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -496,12 +558,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn hypot(self, other: Self) -> Self;
 
     /// Computes the sine of a number (in radians).
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -510,12 +574,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn sin(self) -> Self;
 
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -524,12 +590,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn cos(self) -> Self;
 
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -537,6 +605,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.tan() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-14);
+    /// # }
     /// ```
     fn tan(self) -> Self;
 
@@ -550,6 +619,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if the number is outside the range [-1, 1].
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -559,6 +629,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.sin().asin() - f64::consts::PI / 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn asin(self) -> Self;
 
@@ -572,6 +643,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if the number is outside the range [-1, 1].
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -581,6 +653,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.cos().acos() - f64::consts::PI / 4.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn acos(self) -> Self;
 
@@ -588,6 +661,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// range [-pi/2, pi/2];
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
@@ -596,6 +670,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f.tan().atan() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn atan(self) -> Self;
 
@@ -607,6 +682,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -625,6 +701,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_1 < 1e-10);
     /// assert!(abs_difference_2 < 1e-10);
+    /// # }
     /// ```
     fn atan2(self, other: Self) -> Self;
 
@@ -632,6 +709,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// `(sin(x), cos(x))`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -643,6 +721,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// assert!(abs_difference_0 < 1e-10);
     /// assert!(abs_difference_0 < 1e-10);
+    /// # }
     /// ```
     fn sin_cos(self) -> (Self, Self);
 
@@ -650,6 +729,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// number is close to zero.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
@@ -658,6 +738,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.ln().exp_m1() - 6.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn exp_m1(self) -> Self;
 
@@ -670,6 +751,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// if `self-1 <= 0`.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -679,12 +761,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (x.ln_1p() - 1.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn ln_1p(self) -> Self;
 
     /// Hyperbolic sine function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -697,12 +781,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - g).abs();
     ///
     /// assert!(abs_difference < 1e-10);
+    /// # }
     /// ```
     fn sinh(self) -> Self;
 
     /// Hyperbolic cosine function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -715,12 +801,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// // Same result
     /// assert!(abs_difference < 1.0e-10);
+    /// # }
     /// ```
     fn cosh(self) -> Self;
 
     /// Hyperbolic tangent function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -733,12 +821,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - g).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
+    /// # }
     /// ```
     fn tanh(self) -> Self;
 
     /// Inverse hyperbolic sine function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -747,12 +837,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - x).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
+    /// # }
     /// ```
     fn asinh(self) -> Self;
 
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -761,12 +853,14 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - x).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
+    /// # }
     /// ```
     fn acosh(self) -> Self;
 
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
+    /// # #[cfg(any(feature = "std", feature = "libm"))] {
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -776,6 +870,7 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let abs_difference = (f - e).abs();
     ///
     /// assert!(abs_difference < 1.0e-10);
+    /// # }
     /// ```
     fn atanh(self) -> Self;
 }

--- a/src/real.rs
+++ b/src/real.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use {Float, Num, NumCast};
 
@@ -11,7 +11,7 @@ use {Float, Num, NumCast};
 /// See [this Wikipedia article](https://en.wikipedia.org/wiki/Real_data_type)
 /// for a list of data types that could meaningfully implement this trait.
 ///
-/// This trait is only available with the `std` feature.
+/// This trait is only available with the `std` feature, or with the `libm` feature otherwise.
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///

--- a/src/real.rs
+++ b/src/real.rs
@@ -20,8 +20,8 @@ use Float;
 pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the smallest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -33,8 +33,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest positive, normalized value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -46,8 +46,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns epsilon, a small positive value.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -64,8 +64,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest finite value that this type can represent.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -76,8 +76,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the largest integer less than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.99;
@@ -90,8 +90,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the smallest integer greater than or equal to a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.01;
@@ -105,8 +105,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns the nearest integer to a number. Round half-way cases away from
     /// `0.0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -119,8 +119,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Return the integer part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 3.3;
@@ -133,8 +133,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the fractional part of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.5;
@@ -150,8 +150,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the absolute value of `self`. Returns `Float::nan()` if the
     /// number is `Float::nan()`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -174,8 +174,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
     /// - `Float::nan()` if the number is `Float::nan()`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -191,8 +191,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is positive, including `+0.0`,
     /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -210,8 +210,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `true` if `self` is negative, including `-0.0`,
     /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -232,8 +232,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Using `mul_add` can be more performant than an unfused multiply-add if
     /// the target architecture has a dedicated `fma` CPU instruction.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let m = 10.0;
@@ -249,8 +249,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -264,8 +264,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// Using this function is generally faster than using `powf`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -277,8 +277,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Raise a number to a real number power.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -296,8 +296,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If the implementing type doesn't support NaN, this method should panic if `self < 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let positive = 4.0;
@@ -312,8 +312,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `e^(self)`, (the exponential function).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -329,8 +329,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns `2^(self)`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 2.0;
@@ -348,8 +348,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let one = 1.0;
@@ -369,8 +369,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -393,8 +393,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     ///
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let two = 2.0;
@@ -413,8 +413,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If `self <= 0` and this type does not support a NaN representation, this function should panic.
     ///
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let ten = 10.0;
@@ -428,8 +428,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts radians to degrees.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -442,8 +442,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Converts degrees to radians.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use std::f64::consts;
     ///
     /// let angle = 180.0_f64;
@@ -456,8 +456,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the maximum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -469,8 +469,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Returns the minimum of the two numbers.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -485,8 +485,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * If `self <= other`: `0:0`
     /// * Else: `self - other`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 3.0;
@@ -502,8 +502,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Take the cubic root of a number.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 8.0;
@@ -518,8 +518,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Calculate the length of the hypotenuse of a right-angle triangle given
     /// legs of length `x` and `y`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 2.0;
@@ -534,8 +534,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the sine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -549,8 +549,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the cosine of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -564,8 +564,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Computes the tangent of a number (in radians).
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -585,8 +585,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -608,8 +608,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if the number is outside the range [-1, 1].
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -625,8 +625,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Computes the arctangent of a number. Return value is in radians in the
     /// range [-pi/2, pi/2];
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let f = 1.0;
@@ -645,8 +645,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// * `y >= 0`: `arctan(y/x) + pi` -> `(pi/2, pi]`
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -671,8 +671,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
     /// `(sin(x), cos(x))`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -690,8 +690,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// Returns `e^(self) - 1` in a way that is accurate even if the
     /// number is close to zero.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 7.0;
@@ -711,8 +711,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// If this type does not support a NaN representation, this function should panic
     /// if `self-1 <= 0`.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -727,8 +727,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -746,8 +746,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -765,8 +765,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///
@@ -784,8 +784,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic sine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -799,8 +799,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic cosine function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     ///
     /// let x = 1.0;
@@ -814,8 +814,8 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 
     /// Inverse hyperbolic tangent function.
     ///
-    #[cfg_attr(any(feature = "std", feature = "libm"), doc=" ```")]
-    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc=" ```ignore")]
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = " ```")]
+    #[cfg_attr(not(any(feature = "std", feature = "libm")), doc = " ```ignore")]
     /// use num_traits::real::Real;
     /// use std::f64;
     ///


### PR DESCRIPTION
Greetings,

This is a hopeful fix for #75.  
Basically: Add `libm` as an optional dependency, and handle three possible cases depending on which features are enabled:
- std and libm: std is used;
- std and not libm: std is used;
- libm and not std: libm and FloatCore are used.

It was briefly mentioned that `libm` wasn't ready yet, but this was months ago, and I believe it is better not to wait for too long.  
If anything, bugs in `libm` should be fixed in `libm`; `num-traits` is only delegating its implementations to it; not to mention that the more `libm` is used, the likelier issues are to be found and hopefully fixed.

Thanks in advance!