### PR TITLE
Add inplace methods to `Zero` and `One`

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -1,6 +1,5 @@
 use core::num::Wrapping;
 use core::ops::{Add, Mul};
-use core::mem;
 
 /// Defines an additive identity element for `Self`.
 pub trait Zero: Sized + Add<Self, Output = Self> {
@@ -31,7 +30,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// 0 + a = a       ∀ a ∈ Self
     /// ```
     fn to_zero(&mut self) -> &mut Self {
-        mem::replace(self, Zero::zero());
+        *self = Zero::zero();
         self
     }
 
@@ -115,7 +114,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// 1 * a = a       ∀ a ∈ Self
     /// ```
     fn to_one(&mut self) -> &mut Self {
-        mem::replace(self, One::one());
+        *self = One::one();
         self
     }
 

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -21,9 +21,8 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
 
     /// Sets `self` to the additive identity element of `Self`, `0`.
     /// Returns `&mut self` to enable method chaining.
-    fn set_zero(&mut self) -> &mut Self {
+    fn set_zero(&mut self) {
         *self = Zero::zero();
-        self
     }
 
     /// Returns `true` if `self` is equal to the additive identity.
@@ -73,9 +72,8 @@ where
         self.0.is_zero()
     }
 
-    fn set_zero(&mut self) -> &mut Self {
+    fn set_zero(&mut self) {
         self.0.set_zero();
-        self
     }
 
     fn zero() -> Self {
@@ -103,10 +101,8 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     fn one() -> Self;
 
     /// Sets `self` to the multiplicative identity element of `Self`, `1`.
-    /// Returns `&mut self` to enable method chaining.
-    fn set_one(&mut self) -> &mut Self {
+    fn set_one(&mut self) {
         *self = One::one();
-        self
     }
 
     /// Returns `true` if `self` is equal to the multiplicative identity.
@@ -161,9 +157,8 @@ impl<T: One> One for Wrapping<T>
 where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {
-    fn set_one(&mut self) -> &mut Self {
+    fn set_one(&mut self) {
         self.0.set_one();
-        self
     }
 
     fn one() -> Self {

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -1,5 +1,6 @@
 use core::num::Wrapping;
 use core::ops::{Add, Mul};
+use core::mem;
 
 /// Defines an additive identity element for `Self`.
 pub trait Zero: Sized + Add<Self, Output = Self> {
@@ -19,6 +20,24 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// `static mut`s.
     // This cannot be an associated constant, because of bignums.
     fn zero() -> Self;
+
+    /// Sets `self` to the additive identity element of `Self`, `0`.
+    /// This function may be faster than replacing self with `Zero::zero()`.
+    ///
+    /// # Laws
+    ///
+    /// ```{.text}
+    /// a + 0 = a       ∀ a ∈ Self
+    /// 0 + a = a       ∀ a ∈ Self
+    /// ```
+    ///
+    /// # Purity
+    ///
+    /// This function may return different results depending on the previous state of `self`.
+    fn to_zero(&mut self) -> &mut Self {
+        mem::replace(self, Zero::zero());
+        self
+    }
 
     /// Returns `true` if `self` is equal to the additive identity.
     #[inline]
@@ -89,6 +108,23 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// `static mut`s.
     // This cannot be an associated constant, because of bignums.
     fn one() -> Self;
+
+    /// Sets `self` to the multiplicative identity element of `Self`, `1`.
+    ///
+    /// # Laws
+    ///
+    /// ```{.text}
+    /// a * 1 = a       ∀ a ∈ Self
+    /// 1 * a = a       ∀ a ∈ Self
+    /// ```
+    ///
+    /// # Purity
+    ///
+    /// This function may return different results depending on the previous state of `self`.
+    fn to_zero(&mut self) -> &mut Self {
+        mem::replace(self, One::one());
+        self
+    }
 
     /// Returns `true` if `self` is equal to the multiplicative identity.
     ///

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -20,7 +20,6 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn zero() -> Self;
 
     /// Sets `self` to the additive identity element of `Self`, `0`.
-    /// Returns `&mut self` to enable method chaining.
     fn set_zero(&mut self) {
         *self = Zero::zero();
     }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -2,16 +2,15 @@ use core::num::Wrapping;
 use core::ops::{Add, Mul};
 
 /// Defines an additive identity element for `Self`.
+///
+/// # Laws
+///
+/// ```{.text}
+/// a + 0 = a       ∀ a ∈ Self
+/// 0 + a = a       ∀ a ∈ Self
+/// ```
 pub trait Zero: Sized + Add<Self, Output = Self> {
     /// Returns the additive identity element of `Self`, `0`.
-    ///
-    /// # Laws
-    ///
-    /// ```{.text}
-    /// a + 0 = a       ∀ a ∈ Self
-    /// 0 + a = a       ∀ a ∈ Self
-    /// ```
-    ///
     /// # Purity
     ///
     /// This function should return the same result at all times regardless of
@@ -22,14 +21,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
 
     /// Sets `self` to the additive identity element of `Self`, `0`.
     /// Returns `&mut self` to enable method chaining.
-    ///
-    /// # Laws
-    ///
-    /// ```{.text}
-    /// a + 0 = a       ∀ a ∈ Self
-    /// 0 + a = a       ∀ a ∈ Self
-    /// ```
-    fn to_zero(&mut self) -> &mut Self {
+    fn set_zero(&mut self) -> &mut Self {
         *self = Zero::zero();
         self
     }
@@ -80,21 +72,27 @@ where
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+
+    fn set_zero(&mut self) -> &mut Self {
+        self.0.set_zero();
+        self
+    }
+
     fn zero() -> Self {
         Wrapping(T::zero())
     }
 }
 
 /// Defines a multiplicative identity element for `Self`.
+///
+/// # Laws
+///
+/// ```{.text}
+/// a * 1 = a       ∀ a ∈ Self
+/// 1 * a = a       ∀ a ∈ Self
+/// ```
 pub trait One: Sized + Mul<Self, Output = Self> {
     /// Returns the multiplicative identity element of `Self`, `1`.
-    ///
-    /// # Laws
-    ///
-    /// ```{.text}
-    /// a * 1 = a       ∀ a ∈ Self
-    /// 1 * a = a       ∀ a ∈ Self
-    /// ```
     ///
     /// # Purity
     ///
@@ -106,14 +104,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
 
     /// Sets `self` to the multiplicative identity element of `Self`, `1`.
     /// Returns `&mut self` to enable method chaining.
-    ///
-    /// # Laws
-    ///
-    /// ```{.text}
-    /// a * 1 = a       ∀ a ∈ Self
-    /// 1 * a = a       ∀ a ∈ Self
-    /// ```
-    fn to_one(&mut self) -> &mut Self {
+    fn set_one(&mut self) -> &mut Self {
         *self = One::one();
         self
     }
@@ -138,6 +129,10 @@ macro_rules! one_impl {
             #[inline]
             fn one() -> $t {
                 $v
+            }
+            #[inline]
+            fn is_one(&self) -> bool {
+                *self == $v
             }
         }
     };
@@ -166,6 +161,11 @@ impl<T: One> One for Wrapping<T>
 where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {
+    fn set_one(&mut self) -> &mut Self {
+        self.0.set_one();
+        self
+    }
+
     fn one() -> Self {
         Wrapping(T::one())
     }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -22,7 +22,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn zero() -> Self;
 
     /// Sets `self` to the additive identity element of `Self`, `0`.
-    /// This function may be faster than replacing self with `Zero::zero()`.
+    /// Returns `&mut self` to enable method chaining.
     ///
     /// # Laws
     ///
@@ -30,10 +30,6 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     /// a + 0 = a       ∀ a ∈ Self
     /// 0 + a = a       ∀ a ∈ Self
     /// ```
-    ///
-    /// # Purity
-    ///
-    /// This function may return different results depending on the previous state of `self`.
     fn to_zero(&mut self) -> &mut Self {
         mem::replace(self, Zero::zero());
         self
@@ -110,6 +106,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     fn one() -> Self;
 
     /// Sets `self` to the multiplicative identity element of `Self`, `1`.
+    /// Returns `&mut self` to enable method chaining.
     ///
     /// # Laws
     ///
@@ -117,11 +114,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// a * 1 = a       ∀ a ∈ Self
     /// 1 * a = a       ∀ a ∈ Self
     /// ```
-    ///
-    /// # Purity
-    ///
-    /// This function may return different results depending on the previous state of `self`.
-    fn to_zero(&mut self) -> &mut Self {
+    fn to_one(&mut self) -> &mut Self {
         mem::replace(self, One::one());
         self
     }


### PR DESCRIPTION
Adds the following default implemented methods to `Zero` and `One`:

```rust
fn set_zero(&mut self) {
    *self = Zero::zero();
}
```

```rust
fn set_one(&mut self) {
    *self = One::one();
}
```

This allows for reuse of BigNums.
