### PR TITLE
Add traits for generic norms and distances

### DIFF
--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1,0 +1,73 @@
+use std::ops::{Sub, Div, DivAssign};
+
+use {Num};
+
+pub trait Distance {
+    type Output: Num;
+    fn distance(&self, other: &Self) -> Self::Output;
+}
+
+pub trait Norm: Sized  {
+    type Output: Num;
+    fn norm(&self) -> <Self as Norm>::Output;
+}
+
+pub fn normalize<T: Norm<Output=R> + DivAssign<R>, R: Num>(v: &mut T) {
+    *v /= v.norm();
+}
+
+pub fn normalized<T: Norm<Output=R> + Div<R, Output=T>, R: Num>(v: T) -> T {
+    let norm = v.norm();
+    v / norm
+}
+
+impl<T: Copy + Norm + Sub<Self, Output=Self>> Distance for T{
+    type Output = <Self as Norm>::Output;
+    fn distance(&self, other: &Self) -> <Self as Distance>::Output {
+        (*self - *other).norm()
+    }
+}
+
+
+macro_rules! norm_impl_self {
+    ($($t:ty)*) => ($(
+        impl Norm for $t {
+            type Output = Self;
+            fn norm(&self) -> <Self as Norm>::Output {
+                *self
+            }
+        }
+    )*)
+}
+
+macro_rules! norm_impl_abs {
+    ($($t:ty)*) => ($(
+        impl Norm for $t {
+            type Output = Self;
+            fn norm(&self) -> <Self as Norm>::Output {
+                self.abs()
+            }
+        }
+    )*)
+}
+
+macro_rules! norm_impl_unsigned_output {
+    ($($t:ty, $out:ty);*) => ($(
+        impl Norm for $t {
+            type Output = $out;
+            fn norm(&self) -> <Self as Norm>::Output {
+                self.abs() as $out
+            }
+        }
+    )*)
+}
+
+norm_impl_abs!(f32 f64);
+norm_impl_unsigned_output!(i8, u8; i16, u16; i32, u32; i64, u64; isize, usize);
+norm_impl_self!(u8 u16 u32 u64 usize);
+
+#[cfg(has_i128)]
+norm_impl_unsigned_output!(i128, u128);
+
+#[cfg(has_u128)]
+norm_impl_self!(u128);

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -132,3 +132,35 @@ norm_impl_unsigned_output!(i128, u128);
 
 #[cfg(has_u128)]
 norm_impl_self!(u128);
+
+
+#[test]
+fn norm_floating_point() {
+    assert_eq!((-2.0f32).norm(), 2.0);
+    assert_eq!((-3.0f64).norm(), 3.0);
+}
+
+#[test]
+fn distance_floating_point() {
+    assert_eq!((5.0f32).distance(&3.0), 2.0);
+    assert_eq!((2.0f32).distance(&-3.0), 5.0);
+    assert_eq!((1.0f64).distance(&4.0), 3.0);
+}
+
+#[test]
+fn norm_unsigned_integer() {
+    assert_eq!(2u8.norm(), 2);
+    assert_eq!(3u16.norm(), 3);
+    assert_eq!(4u32.norm(), 4);
+    assert_eq!(5u64.norm(), 5);
+    assert_eq!(6usize.norm(), 6);
+}
+
+#[test]
+fn norm_signed_integer() {
+    assert_eq!((-2i8).norm(), 2);
+    assert_eq!((-3i16).norm(), 3);
+    assert_eq!((-4i32).norm(), 4);
+    assert_eq!((-5i64).norm(), 5);
+    assert_eq!((-6isize).norm(), 6);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod macros;
 
 pub mod bounds;
 pub mod cast;
+pub mod dist;
 pub mod float;
 pub mod identities;
 pub mod int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub use ops::saturating::Saturating;
 pub use ops::wrapping::{WrappingAdd, WrappingMul, WrappingShl, WrappingShr, WrappingSub};
 pub use pow::{checked_pow, pow, Pow};
 pub use sign::{abs, abs_sub, signum, Signed, Unsigned};
+pub use dist::{Norm, Distance};
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This is the implementation mentioned in #121.
Regarding the issue that there are many possible norms for a certain type (see comment https://github.com/rust-num/num-traits/issues/121#issuecomment-526777142 ): I think these traits would only be intended to be implemented on very basic types for which there is some notion of a _standard norm_, like the absolute value on floating point numbers and the euclidean norm on complex numbers and one-dimensional arrays.

Indeed in the meantime I started working a separate crate [Norman](https://gitlab.com/Nuramon27/norman) which handles exactly this issue and provides a set of different norms on a single type.

I hoped that both might go well with each other: having num-traits for a simple answer to the question “how far are these two vectors apart” and a dedicated crate if full control is necessary over how this distance is calculated.