### PR TITLE
Added impl for Zero on Cow<'_, str>

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -86,14 +86,11 @@ where
 impl<'a> Zero for Cow<'a, str> {
 
     fn is_zero(&self) -> bool {
-        match self {
-            Self::Borrowed(str) => str.len() == 0,
-            Self::Owned(string) => string.len() == 0
-        }
+        self.len() == 0
     }
 
     fn zero() -> Self {
-        Self::Borrowed("")
+        Default::default()
     }
 }
 

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -1,6 +1,8 @@
 use core::num::Wrapping;
 use core::ops::{Add, Mul};
 
+#[cfg(feature = "std")] use std::borrow::Cow;
+
 /// Defines an additive identity element for `Self`.
 ///
 /// # Laws
@@ -76,6 +78,22 @@ where
 
     fn zero() -> Self {
         Wrapping(T::zero())
+    }
+}
+
+///Implements Zero as the empty string
+#[cfg(feature = "std")]
+impl<'a> Zero for Cow<'a, str> {
+
+    fn is_zero(&self) -> bool {
+        match self {
+            Self::Borrowed(str) => str.len() == 0,
+            Self::Owned(string) => string.len() == 0
+        }
+    }
+
+    fn zero() -> Self {
+        Self::Borrowed("")
     }
 }
 
@@ -203,4 +221,28 @@ fn wrapping_is_zero() {
 fn wrapping_is_one() {
     fn require_one<T: One>(_: &T) {}
     require_one(&Wrapping(42));
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn cow_is_zero() {
+    fn require_zero<T: Zero>(_: &T) {}
+    require_zero(&Cow::Borrowed("42"));
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn cow_zero() {
+    use std::borrow::ToOwned;
+
+    let s = Cow::Borrowed("num_traits");
+    assert_eq!(s.clone()+Cow::zero(), s);
+    assert_eq!(Cow::zero()+s.clone(), s);
+
+    let s = Cow::<'static,str>::Owned("num_traits".to_owned());
+    assert_eq!(s.clone()+Cow::zero(), s);
+    assert_eq!(Cow::zero()+s.clone(), s);
+
+    assert!(Cow::Borrowed("").is_zero());
+    assert!(Cow::<'static,str>::Owned("".to_owned()).is_zero());
 }


### PR DESCRIPTION
Implements `Zero` as the empty string, `Cow::Borrowed("")`, for `Cow<'_,str>`

Since `Cow<'_,str>` implements `Add`,  `AddAssign`,  and `Clone`, and since string addition does actually constitute a proper mathematical Monoid, I felt it made since to implement the `Zero` trait on `Cow` to complete that connection.

Of course... strings aren't _really_ numbers, so feel free to reject the changes if you guys want to, but it would definitely make the `Zero` trait decently more viable as a general additive identity for more abstract mathematical crates.