### PR TITLE
Trust the "i128" feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,13 @@ use std::env;
 
 fn main() {
     let ac = autocfg::new();
-    if ac.probe_type("i128") {
-        println!("cargo:rustc-cfg=has_i128");
-    } else if env::var_os("CARGO_FEATURE_I128").is_some() {
-        panic!("i128 support was not detected!");
+
+    // If the "i128" feature is explicity requested, don't bother probing for it.
+    // It will still cause a build error if that was set improperly.
+    if env::var_os("CARGO_FEATURE_I128").is_some() || ac.probe_type("i128") {
+        autocfg::emit("has_i128");
     }
+
     ac.emit_expression_cfg(
         "unsafe { 1f64.to_int_unchecked::<i32>() }",
         "has_to_int_unchecked",


### PR DESCRIPTION
If the "i128" feature is explicity requested, don't bother probing for
it. It will still cause a build error if that was set improperly.