### PR TITLE
Allow large f64-to-f32 to saturate to infinity

### DIFF
--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -24,7 +24,8 @@ use core::num::Wrapping;
 #[test]
 fn to_primitive_float() {
     let f32_toolarge = 1e39f64;
-    assert_eq!(f32_toolarge.to_f32(), None);
+    assert_eq!(f32_toolarge.to_f32(), Some(f32::INFINITY));
+    assert_eq!((-f32_toolarge).to_f32(), Some(f32::NEG_INFINITY));
     assert_eq!((f32::MAX as f64).to_f32(), Some(f32::MAX));
     assert_eq!((-f32::MAX as f64).to_f32(), Some(-f32::MAX));
     assert_eq!(f64::INFINITY.to_f32(), Some(f32::INFINITY));


### PR DESCRIPTION
The implementation of `<f64 as ToPrimitive>::to_f32` was written at a
time when float-to-float overflow was though to be undefined behavior,
per rust-lang/rust#15536, but this was later determined to be fine.
Casting a large `f64` to `f32` just results in an infinity with the
matching sign. The sign gives more information than if `to_f32` just
returns `None`, so now we let these infinities through as a result.

See also rust-num/num-bigint#163 and rust-num/num-rational#83.