### PR TITLE
Export trait implementation macros

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -14,6 +14,7 @@ pub trait Bounded {
     fn max_value() -> Self;
 }
 
+#[macro_export]
 macro_rules! bounded_impl {
     ($t:ty, $min:expr, $max:expr) => {
         impl Bounded for $t {

--- a/src/float.rs
+++ b/src/float.rs
@@ -1809,6 +1809,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
 }
 
 #[cfg(feature = "std")]
+#[macro_export]
 macro_rules! float_impl_std {
     ($T:ident $decode:ident) => {
         impl Float for $T {
@@ -1888,6 +1889,7 @@ macro_rules! float_impl_std {
 }
 
 #[cfg(all(not(feature = "std"), feature = "libm"))]
+#[macro_export]
 macro_rules! float_impl_libm {
     ($T:ident $decode:ident) => {
         constant! {
@@ -2242,6 +2244,7 @@ impl Float for f64 {
     }
 }
 
+#[macro_export]
 macro_rules! float_const_impl {
     ($(#[$doc:meta] $constant:ident,)+) => (
         #[allow(non_snake_case)]

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -28,6 +28,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn is_zero(&self) -> bool;
 }
 
+#[macro_export]
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
         impl Zero for $t {
@@ -117,6 +118,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     }
 }
 
+#[macro_export]
 macro_rules! one_impl {
     ($t:ty, $v:expr) => {
         impl One for $t {

--- a/src/int.rs
+++ b/src/int.rs
@@ -306,6 +306,7 @@ pub trait PrimInt:
     fn pow(self, exp: u32) -> Self;
 }
 
+#[macro_export]
 macro_rules! prim_int_impl {
     ($T:ty, $S:ty, $U:ty) => {
         impl PrimInt for $T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ impl<T> NumAssign for T where T: Num + NumAssignOps {}
 pub trait NumAssignRef: NumAssign + for<'r> NumAssignOps<&'r Self> {}
 impl<T> NumAssignRef for T where T: NumAssign + for<'r> NumAssignOps<&'r T> {}
 
+#[macro_export]
 macro_rules! int_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {
@@ -213,6 +214,7 @@ impl fmt::Display for ParseFloatError {
 // FIXME: The standard library from_str_radix on floats was deprecated, so we're stuck
 // with this implementation ourselves until we want to make a breaking change.
 // (would have to drop it from `Num` though)
+#[macro_export]
 macro_rules! float_trait_impl {
     ($name:ident for $($t:ident)*) => ($(
         impl $name for $t {

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -8,6 +8,7 @@ pub trait CheckedAdd: Sized + Add<Self, Output = Self> {
     fn checked_add(&self, v: &Self) -> Option<Self>;
 }
 
+#[macro_export]
 macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {
@@ -147,6 +148,7 @@ checked_impl!(CheckedRem, checked_rem, isize);
 #[cfg(has_i128)]
 checked_impl!(CheckedRem, checked_rem, i128);
 
+#[macro_export]
 macro_rules! checked_impl_unary {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {
@@ -214,6 +216,7 @@ pub trait CheckedShl: Sized + Shl<u32, Output = Self> {
     fn checked_shl(&self, rhs: u32) -> Option<Self>;
 }
 
+#[macro_export]
 macro_rules! checked_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -54,6 +54,7 @@ impl MulAdd<f64, f64> for f64 {
     }
 }
 
+#[macro_export]
 macro_rules! mul_add_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         impl $trait_name for $t {
@@ -87,6 +88,7 @@ impl MulAddAssign<f64, f64> for f64 {
     }
 }
 
+#[macro_export]
 macro_rules! mul_add_assign_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         impl $trait_name for $t {

--- a/src/ops/overflowing.rs
+++ b/src/ops/overflowing.rs
@@ -4,6 +4,7 @@ use core::{i128, u128};
 use core::{i16, i32, i64, i8, isize};
 use core::{u16, u32, u64, u8, usize};
 
+#[macro_export]
 macro_rules! overflowing_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -12,6 +12,7 @@ pub trait Saturating {
     fn saturating_sub(self, v: Self) -> Self;
 }
 
+#[macro_export]
 macro_rules! deprecated_saturating_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         impl $trait_name for $t {
@@ -32,6 +33,7 @@ deprecated_saturating_impl!(Saturating for isize usize i8 u8 i16 u16 i32 u32 i64
 #[cfg(has_i128)]
 deprecated_saturating_impl!(Saturating for i128 u128);
 
+#[macro_export]
 macro_rules! saturating_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -1,6 +1,7 @@
 use core::num::Wrapping;
 use core::ops::{Add, Mul, Neg, Shl, Shr, Sub};
 
+#[macro_export]
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {
@@ -89,6 +90,7 @@ wrapping_impl!(WrappingMul, wrapping_mul, isize);
 #[cfg(has_i128)]
 wrapping_impl!(WrappingMul, wrapping_mul, i128);
 
+#[macro_export]
 macro_rules! wrapping_unary_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {
@@ -137,6 +139,7 @@ wrapping_unary_impl!(WrappingNeg, wrapping_neg, isize);
 #[cfg(has_i128)]
 wrapping_unary_impl!(WrappingNeg, wrapping_neg, i128);
 
+#[macro_export]
 macro_rules! wrapping_shift_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -18,6 +18,7 @@ pub trait Pow<RHS> {
     fn pow(self, rhs: RHS) -> Self::Output;
 }
 
+#[macro_export]
 macro_rules! pow_impl {
     ($t:ty) => {
         pow_impl!($t, u8);

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -41,6 +41,7 @@ pub trait Signed: Sized + Num + Neg<Output = Self> {
     fn is_negative(&self) -> bool;
 }
 
+#[macro_export]
 macro_rules! signed_impl {
     ($($t:ty)*) => ($(
         impl Signed for $t {
@@ -107,6 +108,7 @@ where
     }
 }
 
+#[macro_export]
 macro_rules! signed_float_impl {
     ($t:ty) => {
         impl Signed for $t {
@@ -196,6 +198,7 @@ pub fn signum<T: Signed>(value: T) -> T {
 /// A trait for values which cannot be negative
 pub trait Unsigned: Num {}
 
+#[macro_export]
 macro_rules! empty_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {}


### PR DESCRIPTION
The trait implementation macros are quite useful for other crates which may choose to implement numeric types. This patch exports those macros to facilitate this.

[Here](https://github.com/dalek-cryptography/curve25519-dalek/blob/e69be46e22ca5e8ba5aae2cdbdc886d1d2db55e8/src/scalar.rs#L1143) is an example scenario where it would be quite useful to have access to these macros down stream.