### PR TITLE
Use standard library for float from_str_radix with radix 10

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ macro_rules! float_trait_impl {
                     "inf"   => return Ok(core::$t::INFINITY),
                     "-inf"  => return Ok(core::$t::NEG_INFINITY),
                     "NaN"   => return Ok(core::$t::NAN),
+                    "-NaN"  => return Ok(-core::$t::NAN),
                     _       => {},
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,13 @@ macro_rules! float_trait_impl {
                 use self::FloatErrorKind::*;
                 use self::ParseFloatError as PFE;
 
+                // Special case radix 10 to use more accurate standard library implementation
+                if radix == 10 {
+                    return src.parse().map_err(|_| PFE {
+                        kind: if src.is_empty() { Empty } else { Invalid },
+                    });
+                }
+
                 // Special values
                 match src {
                     "inf"   => return Ok(core::$t::INFINITY),


### PR DESCRIPTION
Fixes #198.

While at it, also make parsing of the `"-NaN"` string match the standard library.