### PR TITLE
Add leading_ones and trailing_ones to PrimInt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,5 +16,7 @@ fn main() {
         "has_to_int_unchecked",
     );
 
+    ac.emit_expression_cfg("1u32.trailing_ones()", "has_leading_trailing_ones");
+
     autocfg::rerun_path("build.rs");
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -78,6 +78,22 @@ pub trait PrimInt:
     /// ```
     fn count_zeros(self) -> u32;
 
+    /// Returns the number of leading ones in the binary representation
+    /// of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_traits::PrimInt;
+    ///
+    /// let n = 0xF00Du16;
+    ///
+    /// assert_eq!(n.leading_ones(), 4);
+    /// ```
+    fn leading_ones(self) -> u32 {
+        (!self).leading_zeros()
+    }
+
     /// Returns the number of leading zeros in the binary representation
     /// of `self`.
     ///
@@ -91,6 +107,22 @@ pub trait PrimInt:
     /// assert_eq!(n.leading_zeros(), 10);
     /// ```
     fn leading_zeros(self) -> u32;
+
+    /// Returns the number of trailing ones in the binary representation
+    /// of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_traits::PrimInt;
+    ///
+    /// let n = 0xBEEFu16;
+    ///
+    /// assert_eq!(n.trailing_ones(), 4);
+    /// ```
+    fn trailing_ones(self) -> u32 {
+        (!self).trailing_zeros()
+    }
 
     /// Returns the number of trailing zeros in the binary representation
     /// of `self`.
@@ -319,9 +351,21 @@ macro_rules! prim_int_impl {
                 <$T>::count_zeros(self)
             }
 
+            #[cfg(has_leading_leading_ones)]
+            #[inline]
+            fn leading_ones(self) -> u32 {
+                <$T>::leading_ones(self)
+            }
+
             #[inline]
             fn leading_zeros(self) -> u32 {
                 <$T>::leading_zeros(self)
+            }
+
+            #[cfg(has_leading_trailing_ones)]
+            #[inline]
+            fn trailing_ones(self) -> u32 {
+                <$T>::trailing_ones(self)
             }
 
             #[inline]


### PR DESCRIPTION
Since this was only stabilised in 1.46.0, it falls back to a naïve version on older versions.

It seems unlikely that the version in libstd will ever be different from calling the zeros versions on !self, but for future-proofing, this defers to the libstd versions anyway.