### PR TITLE
Support conversion of primitive integer types in `const` context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+rust-toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-num/num-traits"
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 readme = "README.md"
 build = "build.rs"
 exclude = ["/bors.toml", "/ci/*", "/.github/*"]
@@ -23,6 +23,7 @@ libm = { version = "0.2.0", optional = true }
 default = ["std"]
 std = []
 i128 = []
+const_conversion = []
 
 [build-dependencies]
 autocfg = "1"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ Implementations for `i128` and `u128` are only available with Rust 1.26 and
 later.  The build script automatically detects this, but you can make it
 mandatory by enabling the `i128` crate feature.
 
+The `const_conversion` feature makes it possible to perform `ToPrimitive`
+conversions in `const` context (e.g.:
+```
+const FORTY_TWO: u64 = 42;
+const FOO: u8 = FORTY_TWO.to_u8().unwrap();
+```
+Note that `unwrap()` in `const` context **does not panic**, but instead, *halts
+compilation*, thereby ensuring validity at compile-time instead of 
+runtime.
+
+As of the time of this writing, the `const_trait_impl` feature in current
+Rust (v1.56) is not yet stable.  When it does appear in stable Rust, `num-traits`
+is set up to enable it automatically if it is stable in your compiler version.
+
+If you wish to use this feature before then, set your project to a recent nightly 
+version of the Rust compiler and enable the `const_conversion` feature by adding 
+the following to the `[dependencies]`section of your `Cargo.toml` file:
+```toml
+# Cargo.toml
+[dependencies]
+# ... other dependencies your crate may have
+num-traits = { version = "0.2.15", features = ["const_conversion"] }
+```
+
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+# Release 0.2.15 (2020-10-23)
+
+- Add `const_conversion` feature enabling conversions between primitive integer
+  types in `const` context.  Enabled automatically once [rust#67792] stabilizes.
+
+**Contributors**: @U007D
+[rust#67792]: https://github.com/rust-lang/rust/issues/67792
 # Release 0.2.14 (2020-10-29)
 
 - Clarify the license specification as "MIT OR Apache-2.0".

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,14 @@ fn main() {
 
     ac.emit_expression_cfg("1u32.reverse_bits()", "has_reverse_bits");
     ac.emit_expression_cfg("1u32.trailing_ones()", "has_leading_trailing_ones");
+    ac.emit_expression_cfg(
+        r#"
+            trait TestTrait {}
+            struct TestType {}
+            impl const TestTrait for TestType {}
+        "#,
+        "has_const_trait_impl",
+    );
 
     autocfg::rerun_path("build.rs");
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -165,8 +165,8 @@ macro_rules! impl_to_primitive_int_to_uint {
 }
 
 macro_rules! impl_to_primitive_int {
-    ($T:ident) => {
-        impl ToPrimitive for $T {
+    ($T:ident $($const_kw:ident)?) => {
+        impl $($const_kw)? ToPrimitive for $T {
             impl_to_primitive_int_to_int! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -199,13 +199,32 @@ macro_rules! impl_to_primitive_int {
     };
 }
 
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_int!(isize);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_int!(i8);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_int!(i16);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_int!(i32);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_int!(i64);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 #[cfg(has_i128)]
 impl_to_primitive_int!(i128);
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(isize const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(i8 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(i16 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(i32 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(i64 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_int!(i128 const);
 
 macro_rules! impl_to_primitive_uint_to_int {
     ($SrcT:ident : $( $(#[$cfg:meta])* fn $method:ident -> $DstT:ident ; )*) => {$(
@@ -238,8 +257,8 @@ macro_rules! impl_to_primitive_uint_to_uint {
 }
 
 macro_rules! impl_to_primitive_uint {
-    ($T:ident) => {
-        impl ToPrimitive for $T {
+    ($T:ident $($const_kw:ident)?) => {
+        impl $($const_kw)? ToPrimitive for $T {
             impl_to_primitive_uint_to_int! { $T:
                 fn to_isize -> isize;
                 fn to_i8 -> i8;
@@ -272,13 +291,33 @@ macro_rules! impl_to_primitive_uint {
     };
 }
 
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_uint!(usize);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_uint!(u8);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_uint!(u16);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_uint!(u32);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 impl_to_primitive_uint!(u64);
+#[cfg(not(any(has_const_trait_impl, feature = "const_conversion")))]
 #[cfg(has_i128)]
 impl_to_primitive_uint!(u128);
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_uint!(usize const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_uint!(u8 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_uint!(u16 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_uint!(u32 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+impl_to_primitive_uint!(u64 const);
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[cfg(has_i128)]
+impl_to_primitive_uint!(u128 const);
 
 macro_rules! impl_to_primitive_float_to_float {
     ($SrcT:ident : $( fn $method:ident -> $DstT:ident ; )*) => {$(

--- a/src/float.rs
+++ b/src/float.rs
@@ -169,6 +169,7 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     /// check(f64::NAN, true);
     /// check(0.0f64, false);
     /// ```
+    #[allow(clippy::eq_op)]
     #[inline]
     fn is_nan(self) -> bool {
         self != self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 #![doc(html_root_url = "https://docs.rs/num-traits/0.2")]
 #![deny(unconditional_recursion)]
 #![no_std]
+#![cfg_attr(feature = "const_conversion", feature(const_trait_impl))]
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,7 @@ pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
 ///  `clamp_min(std::f32::NAN, 1.0)` preserves `NAN` different from `f32::min(std::f32::NAN, 1.0)`.
 ///
 /// **Panics** in debug mode if `!(min == min)`. (This occurs if `min` is `NAN`.)
+#[allow(clippy::eq_op)]
 #[inline]
 pub fn clamp_min<T: PartialOrd>(input: T, min: T) -> T {
     debug_assert!(min == min, "min must not be NAN");
@@ -441,6 +442,7 @@ pub fn clamp_min<T: PartialOrd>(input: T, min: T) -> T {
 ///  `clamp_max(std::f32::NAN, 1.0)` preserves `NAN` different from `f32::max(std::f32::NAN, 1.0)`.
 ///
 /// **Panics** in debug mode if `!(max == max)`. (This occurs if `max` is `NAN`.)
+#[allow(clippy::eq_op)]
 #[inline]
 pub fn clamp_max<T: PartialOrd>(input: T, max: T) -> T {
     debug_assert!(max == max, "max must not be NAN");

--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -78,6 +78,7 @@ fn wrapping_is_numcast() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn as_primitive() {
     let x: f32 = (1.625f64).as_();
     assert_eq!(x, 1.625f32);

--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -1,6 +1,7 @@
 //! Tests of `num_traits::cast`.
 
 #![no_std]
+#![cfg_attr(feature = "const_conversion", feature(const_trait_impl))]
 
 #[cfg(feature = "std")]
 #[macro_use]
@@ -366,6 +367,10 @@ fn newtype_to_primitive() {
 
     // minimal impl
     impl<T: ToPrimitive> ToPrimitive for New<T> {
+        fn to_i8(&self) -> Option<i8> {
+            self.0.to_i8()
+        }
+
         fn to_i64(&self) -> Option<i64> {
             self.0.to_i64()
         }
@@ -395,4 +400,132 @@ fn newtype_to_primitive() {
     }
     check!(i8 i16 i32 i64 isize);
     check!(u8 u16 u32 u64 usize);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn valid_int_to_int_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: i64 = -42;
+    const EXPECTED: Option<i8> = Some(-42);
+
+    // When
+    const RESULT: Option<i8> = VALUE.to_i8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn valid_int_to_uint_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: i64 = 42;
+    const EXPECTED: Option<u8> = Some(42);
+
+    // When
+    const RESULT: Option<u8> = VALUE.to_u8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn valid_unt_to_uint_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: u64 = 42;
+    const EXPECTED: Option<u8> = Some(42);
+
+    // When
+    const RESULT: Option<u8> = VALUE.to_u8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn valid_unt_to_int_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: u64 = 42;
+    const EXPECTED: Option<i8> = Some(42);
+
+    // When
+    const RESULT: Option<i8> = VALUE.to_i8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn invalid_int_to_int_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: i64 = -129;
+    const EXPECTED: Option<i8> = None;
+
+    // When
+    const RESULT: Option<i8> = VALUE.to_i8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn invalid_int_to_uint_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: i64 = -1;
+    const EXPECTED: Option<u8> = None;
+
+    // When
+    const RESULT: Option<u8> = VALUE.to_u8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn invalid_unt_to_uint_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: u64 = 256;
+    const EXPECTED: Option<u8> = None;
+
+    // When
+    const RESULT: Option<u8> = VALUE.to_u8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
+}
+
+#[cfg(any(has_const_trait_impl, feature = "const_conversion"))]
+#[test]
+fn invalid_unt_to_int_const_cast_succeeds() {
+    use crate::ToPrimitive;
+
+    // Given
+    const VALUE: u64 = 128;
+    const EXPECTED: Option<i8> = None;
+
+    // When
+    const RESULT: Option<i8> = VALUE.to_i8();
+
+    // Then
+    assert!(RESULT == EXPECTED);
 }


### PR DESCRIPTION
Support primitive integer conversion via new `const_conversion` feature or when building with a version of the compiler where `const_trait_impl` has stabilized.