### PR TITLE
feat: self-referential bounded trait for generics

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -10,8 +10,10 @@ pub trait Bounded {
     // FIXME (#5527): These should be associated constants
     /// Returns the smallest finite number this type can represent
     fn min_value() -> Self;
+    fn own_min_value(&self) -> Self;
     /// Returns the largest finite number this type can represent
     fn max_value() -> Self;
+    fn own_max_value(&self) -> Self;
 }
 
 /// Numbers which have lower bounds
@@ -52,6 +54,16 @@ macro_rules! bounded_impl {
             fn max_value() -> $t {
                 $max
             }
+
+            #[inline]
+            fn own_max_value(&self) -> $t {
+                $max
+            }
+
+            #[inline]
+            fn own_min_value(&self) -> $t {
+                $max
+            }
         }
     };
 }
@@ -77,6 +89,12 @@ impl<T: Bounded> Bounded for Wrapping<T> {
         Wrapping(T::min_value())
     }
     fn max_value() -> Self {
+        Wrapping(T::max_value())
+    }
+    fn own_min_value(&self) -> Self {
+        Wrapping(T::min_value())
+    }
+    fn own_max_value(&self) -> Self {
         Wrapping(T::max_value())
     }
 }
@@ -107,6 +125,14 @@ macro_rules! bounded_tuple {
             }
             #[inline]
             fn max_value() -> Self {
+                ($($name::max_value(),)*)
+            }
+            #[inline]
+            fn own_min_value(&self) -> Self {
+                ($($name::min_value(),)*)
+            }
+            #[inline]
+            fn own_max_value(&self) -> Self {
                 ($($name::max_value(),)*)
             }
         }


### PR DESCRIPTION
I was using this crate to recieve a generic number T bounded by this create's traits more specifically the 'Bounded' trait since I needed the upper bounds for some audio calculations, (wav sample format conversion) but I only have the instance of a number and would be much more convenient to have a "self referenced" edititon of the  `Bounded::max_value`  method to enable stuff like:

```rust
fn unwrap_sample<Sample>(sample_result: Result<Sample, hound::Error>) -> f32
where
  Sample: Num + Bounded + ToPrimitive,
{
  let sample_val = sample_result.unwrap();
  let max = sample_val.own_max_value();
  return sample_val.div(max).to_f32().unwrap();
}
```