### PR TITLE
Atomic Traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libm = { version = "0.2.0", optional = true }
 [features]
 default = ["std"]
 std = []
+atomic_from_mut = []
 
 # vestigial features, now always in effect
 i128 = []

--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -1,0 +1,215 @@
+use core::sync::atomic::*;
+
+pub trait Atomic: Sized {
+    type NonAtomicType: Copy;
+
+    fn new(value: Self::NonAtomicType) -> Self;
+    fn load(&self, order: Ordering) -> Self::NonAtomicType;
+    fn store(&self, value: Self::NonAtomicType, order: Ordering);
+    fn get_mut(&mut self) -> &mut Self::NonAtomicType;
+    fn into_inner(self) -> Self::NonAtomicType;
+
+    fn compare_exchange(
+        &self,
+        current: Self::NonAtomicType,
+        new: Self::NonAtomicType,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType>;
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::NonAtomicType,
+        new: Self::NonAtomicType,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType>;
+
+    fn swap(
+        &self,
+        new: Self::NonAtomicType,
+        order: Ordering,
+    ) -> Self::NonAtomicType;
+
+    fn fetch_add(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_and(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_max(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_min(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_nand(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_or(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_sub(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+    fn fetch_xor(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType;
+
+    fn fetch_update<F>(
+        &self, 
+        set_order: Ordering, 
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType>
+    where
+        F: FnMut(Self::NonAtomicType) -> Option<Self::NonAtomicType>;
+}
+
+/// While this trait doesn't do much, it allows to use the dual specification.
+/// The impl automatically mirrors the [`Atomic`] trait so
+/// 
+/// E.g.:
+/// ```ignore
+/// fn to_atomic<T: IntoAtomic>(value: T) -> T::AtomicType {
+///     <T::AtomicType>::new(value)
+/// }
+/// ```
+/// instead of
+/// ```ignore
+/// fn to_atomic<R: Atomic>(value: R::NonAtomicType) -> R {
+///     <R>::new(value)
+/// }
+/// ```
+pub trait IntoAtomic {
+    type AtomicType: Atomic<NonAtomicType=Self>;
+}
+
+macro_rules! impl_atomic_trait {
+    ($($non_atomic:ty, $atomic:ty,)*) => {$(
+
+impl IntoAtomic for $non_atomic {
+    type AtomicType = $atomic;
+}
+
+impl Atomic for $atomic {
+    type NonAtomicType = $non_atomic;
+
+    #[inline]
+    fn new(value: Self::NonAtomicType) -> Self {
+        <$atomic>::new(value)
+    }
+
+    #[inline]
+    fn load(&self, order: Ordering) -> Self::NonAtomicType {
+        <$atomic>::load(self, order)
+    }
+
+    #[inline]
+    fn store(&self, value: Self::NonAtomicType, order: Ordering) {
+        <$atomic>::store(self, value, order)
+    }
+
+    #[inline]
+    fn get_mut(&mut self) -> &mut Self::NonAtomicType {
+        <$atomic>::get_mut(self)
+    }
+
+    #[inline]
+    fn into_inner(self) -> Self::NonAtomicType {
+        <$atomic>::into_inner(self)
+    }
+
+    #[inline]
+    fn compare_exchange(
+        &self,
+        current: Self::NonAtomicType,
+        new: Self::NonAtomicType,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType> {
+        <$atomic>::compare_exchange(
+            self,
+            current,
+            new,
+            success,
+            failure,
+        )
+    }
+
+
+    #[inline]    
+    fn compare_exchange_weak(
+        &self,
+        current: Self::NonAtomicType,
+        new: Self::NonAtomicType,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType>{
+        <$atomic>::compare_exchange_weak(
+            self,
+            current,
+            new,
+            success,
+            failure,
+        )
+    }
+
+    #[inline]
+    fn swap(
+        &self,
+        new: Self::NonAtomicType,
+        order: Ordering,
+    ) -> Self::NonAtomicType{
+        <$atomic>::swap(
+            self,
+            new,
+            order,
+        )
+    }
+
+    #[inline]
+    fn fetch_add(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_add(self, value, order)
+    }
+    #[inline]
+    fn fetch_and(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_and(self, value, order)
+    }
+    #[inline]
+    fn fetch_max(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_max(self, value, order)
+    }
+    #[inline]
+    fn fetch_min(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_min(self, value, order)
+    }
+    #[inline]
+    fn fetch_nand(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_nand(self, value, order)
+    }
+    #[inline]
+    fn fetch_or(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_or(self, value, order)
+    }
+    #[inline]
+    fn fetch_sub(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_sub(self, value, order)
+    }
+    #[inline]
+    fn fetch_xor(&self, value: Self::NonAtomicType, order: Ordering) -> Self::NonAtomicType{
+        <$atomic>::fetch_xor(self, value, order)
+    }
+
+    #[inline]
+    fn fetch_update<F>(
+        &self, 
+        set_order: Ordering, 
+        fetch_order: Ordering,
+        f: F,
+    ) -> Result<Self::NonAtomicType, Self::NonAtomicType>
+    where
+        F: FnMut(Self::NonAtomicType) -> Option<Self::NonAtomicType> {
+        <$atomic>::fetch_update(self, set_order, fetch_order, f)
+    }
+}
+
+)*};
+}
+
+impl_atomic_trait!{
+    u8,  AtomicU8,
+    u16, AtomicU16,
+    u32, AtomicU32,
+    u64, AtomicU64,
+    usize, AtomicUsize,
+    i8,  AtomicI8,
+    i16, AtomicI16,
+    i32, AtomicI32,
+    i64, AtomicI64,
+    isize, AtomicIsize,
+}

--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::*;
 
-pub trait Atomic: Sized {
+pub trait Atomic: Sized + Send + Sync {
     type NonAtomicType: Copy;
 
     fn new(value: Self::NonAtomicType) -> Self;

--- a/src/coerced.rs
+++ b/src/coerced.rs
@@ -10,6 +10,7 @@ macro_rules! macro_impl_coerce {
                 fn coerce_into(self) -> $tyy {
                     self as $tyy
                 }
+                
                 fn coerce_from(other: $tyy) -> Self {
                     other as $ty
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 #![doc(html_root_url = "https://docs.rs/num-traits/0.2")]
 #![deny(unconditional_recursion)]
 #![no_std]
+#![cfg_attr(feature="atomic_from_mut", feature(atomic_from_mut))]
 
 // Need to explicitly bring the crate in for inherent float methods
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub use crate::ops::wrapping::{
 };
 pub use crate::pow::{checked_pow, pow, Pow};
 pub use crate::sign::{abs, abs_sub, signum, Signed, Unsigned};
+pub use crate::atomics::{Atomic, IntoAtomic};
 
 #[macro_use]
 mod macros;
@@ -60,6 +61,7 @@ pub mod ops;
 pub mod pow;
 pub mod real;
 pub mod sign;
+pub mod atomics;
 
 /// The base trait for numeric types, covering `0` and `1` values,
 /// comparisons, basic numeric operations, and string conversion.

--- a/tests/coerce.rs
+++ b/tests/coerce.rs
@@ -1,0 +1,33 @@
+//! Tests of `num_traits::cast`.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use num_traits::Coerced;
+
+use core::{f32, f64};
+use core::{i128, i16, i32, i64, i8, isize};
+use core::{u128, u16, u32, u64, u8, usize};
+
+macro_rules! test_stuff {
+    ($t1:ty, $($t2:ty)*) => {
+        $(
+            assert_eq!(<$t1 as Coerced<$t2>>::coerce_into(0x5 as $t1), 0x5 as $t2);
+        )*
+    };
+}
+
+macro_rules! testerino {
+    ($($ty:ty)*) => {
+        $(
+            test_stuff!($ty, f32 f64 i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 usize);
+        )*
+    };
+}
+
+#[test]
+fn test_coerce() {
+    let x: u64 = 0xff_u8.coerce_into();
+    assert_eq!(x, 0xff_u64);
+
+    testerino!(f32 f64 i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 usize);
+}


### PR DESCRIPTION
Hi! I've added my implementation of `Atomic` and `IntoAtomic`, I use them really often and they are quite similar to your traits so I think that they might be a good fit in your library.
I still have to write documentation and examples, but I wanted to know what you think about this.

Also, we could add the opt-in support for the methods from the unstable feature `#![feature(atomic_from_mut)]` by adding an enabling feature to the create. 