### PR TITLE
Add `CheckedSum` and `CheckedProduct` traits

### DIFF
--- a/src/iter/checked_product.rs
+++ b/src/iter/checked_product.rs
@@ -1,0 +1,95 @@
+use crate::identities::One;
+use crate::CheckedMul;
+
+/// This trait represents types of which an iterator can be multiplied up with overflow checking.
+/// This trait should rarely be called directly.
+pub trait CheckedProduct<Result = Self> {
+    /// Multiplies up the elements of an iterator, returning `None` if an overflow would occur.
+    ///
+    /// Multiplies up an empty iterator returns a value representing One.
+    ///
+    /// If the iterator contains Zero, the order of elements may effect whether the result is `None`.
+    fn checked_product<I: Iterator<Item = Self>>(iter: I) -> Option<Result>;
+}
+
+impl<T> CheckedProduct<T> for T
+where
+    T: CheckedMul + One,
+{
+    fn checked_product<I: Iterator<Item = Self>>(mut iter: I) -> Option<Self> {
+        iter.try_fold(Self::one(), |acc, x| acc.checked_mul(&x))
+    }
+}
+
+impl<'a, T> CheckedProduct<T> for &'a T
+where
+    T: CheckedMul + Sized + One,
+{
+    fn checked_product<I: Iterator<Item = Self>>(mut iter: I) -> Option<T> {
+        iter.try_fold(T::one(), |acc, x| acc.checked_mul(x))
+    }
+}
+
+///This trait is for iterators that can be multiplied up with overflow checking.
+trait CheckedProductIter<T, Result>: Iterator<Item = T> {
+    /// Multiplies up the elements of an iterator, returning `None` if an overflow would occur.
+    ///
+    /// Multiplies up an empty iterator returns a value representing One.
+    ///
+    /// If the iterator contains Zero, the order of elements may effect whether the result is `None`.
+    fn checked_product(self) -> Option<Result>;
+}
+
+impl<Result, T: CheckedProduct<Result>, I: Iterator<Item = T>> CheckedProductIter<T, Result> for I {
+    fn checked_product(self) -> Option<Result> {
+        T::checked_product(self)
+    }
+}
+
+#[test]
+fn checked_product_returns_none_instead_of_overflowing() {
+    macro_rules! test_checked_product {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(None, [<$t>::MAX, 2 ].iter().checked_product() );
+                assert_eq!(None,IntoIterator::into_iter([<$t>::MAX, 2]).checked_product() );
+            )+
+        };
+    }
+
+    test_checked_product!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_product_returns_one_if_empty() {
+    macro_rules! test_checked_product {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(Some(<$t>::one()), ([] as [$t; 0]).iter().checked_product() );
+                assert_eq!(Some(<$t>::one()),IntoIterator::into_iter(([] as [$t; 0])).checked_product() );
+            )+
+        };
+    }
+
+    test_checked_product!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_product_returns_correct_product() {
+    macro_rules! test_checked_product {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(Some(42), ([3,7,2] as [$t; 3]).iter().checked_product() );
+                assert_eq!(Some(42),IntoIterator::into_iter(([3,7,2] as [$t; 3])).checked_product() );
+            )+
+        };
+    }
+
+    test_checked_product!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_product_multiplies_left_to_right() {
+    assert_eq!(None, [100u8, 3u8, 0u8].iter().checked_product());
+    assert_eq!(Some(0), [0u8, 100u8, 3u8].iter().checked_product());
+}

--- a/src/iter/checked_sum.rs
+++ b/src/iter/checked_sum.rs
@@ -1,0 +1,97 @@
+use crate::identities::Zero;
+use crate::CheckedAdd;
+
+/// This trait represents types of which an iterator can be summed up with overflow checking.
+/// This trait should rarely be called directly.
+pub trait CheckedSum<Result = Self> {
+    /// Adds the elements of an iterator, returning `None` if an overflow would occur.
+    ///
+    /// Summing an empty iterator returns a value representing Zero.
+    ///
+    /// For signed numbers, the order of elements may effect whether the result is `None`.    
+    fn checked_sum<I: Iterator<Item = Self>>(iter: I) -> Option<Result>;
+}
+
+impl<T> CheckedSum<T> for T
+where
+    T: CheckedAdd + Zero,
+{
+    fn checked_sum<I: Iterator<Item = Self>>(mut iter: I) -> Option<Self> {
+        iter.try_fold(Self::zero(), |acc, x| acc.checked_add(&x))
+    }
+}
+
+impl<'a, T> CheckedSum<T> for &'a T
+where
+    T: CheckedAdd + Sized + Zero,
+{
+    fn checked_sum<I: Iterator<Item = Self>>(mut iter: I) -> Option<T> {
+        iter.try_fold(T::zero(), |acc, x| acc.checked_add(x))
+    }
+}
+
+///This trait is for iterators that can be summed up with overflow checking.
+trait CheckedSumIter<T, Result>: Iterator<Item = T> {
+    /// Adds the elements of an iterator, returning `None` if an overflow would occur.
+    ///
+    /// Summing an empty iterator returns a value representing Zero.
+    ///
+    /// For signed numbers, the order of elements may effect whether the result is `None`.    
+    fn checked_sum(self) -> Option<Result>;
+}
+
+impl<Result, T: CheckedSum<Result>, I: Iterator<Item = T>> CheckedSumIter<T, Result> for I {
+    fn checked_sum(self) -> Option<Result> {
+        T::checked_sum(self)
+    }
+}
+
+#[test]
+fn checked_sum_returns_none_instead_of_overflowing() {
+    use crate::identities::One;
+
+    macro_rules! test_checked_sum {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(None, [<$t>::MAX, <$t>::one()].iter().checked_sum() );
+                assert_eq!(None,IntoIterator::into_iter([<$t>::MAX, <$t>::one()]).checked_sum() );
+            )+
+        };
+    }
+
+    test_checked_sum!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_sum_returns_zero_if_empty() {
+    macro_rules! test_checked_sum {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(Some(<$t>::zero()), ([] as [$t; 0]).iter().checked_sum() );
+                assert_eq!(Some(<$t>::zero()),IntoIterator::into_iter(([] as [$t; 0])).checked_sum() );
+            )+
+        };
+    }
+
+    test_checked_sum!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_sum_returns_correct_sum() {
+    macro_rules! test_checked_sum {
+        ($($t:ty)+) => {
+            $(
+                assert_eq!(Some(42), ([40,2] as [$t; 2]).iter().checked_sum() );
+                assert_eq!(Some(42),IntoIterator::into_iter(([40,2] as [$t; 2])).checked_sum() );
+            )+
+        };
+    }
+
+    test_checked_sum!(usize u8 u16 u32 u64 isize i8 i16 i32 i64);
+}
+
+#[test]
+fn checked_sum_adds_left_to_right() {
+    assert_eq!(None, [120i8, 8i8, -1i8].iter().checked_sum());
+    assert_eq!(Some(127), [-1i8, 120i8, 8i8].iter().checked_sum());
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,0 +1,2 @@
+pub mod checked_product;
+pub mod checked_sum;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,2 +1,3 @@
 pub mod checked_product;
 pub mod checked_sum;
+pub mod num_iter;

--- a/src/iter/num_iter.rs
+++ b/src/iter/num_iter.rs
@@ -1,0 +1,50 @@
+use crate::CheckedProduct;
+use crate::CheckedSum;
+
+/// An [`Iterator`] blanket implementation that provides extra adaptors and
+/// methods.
+///
+/// This traits defines methods for summing and multiplying together iterators with overflow checking.
+pub trait NumIter: Iterator {
+    /// Sums the elements of an iterator with overflow checking.
+    ///
+    /// Takes each element, adds them together, and returns the result or None if the addition would overflow.
+    ///
+    /// An empty iterator returns the zero value of the type.
+    ///
+    /// For signed numbers, the order of elements may effect whether the result is `None`.
+    fn checked_sum<A, T: CheckedSum<A>>(self) -> Option<T>
+    where
+        Self: Iterator<Item = A>,
+        Self: Sized;
+
+    /// Iterates over the entire iterator, multiplying all the elements with overflow checking.
+    ///
+    /// Takes each element, multiplies them together, and returns the result or None if the multiplication would overflow.
+    ///
+    /// An empty iterator returns the one value of the type.
+    ///
+    /// For iterators containing zero, the order of elements may effect whether the result is `None`.
+    fn checked_product<A, T: CheckedProduct<A>>(self) -> Option<T>
+    where
+        Self: Iterator<Item = A>,
+        Self: Sized;
+}
+
+impl<I: Iterator> NumIter for I {
+    fn checked_sum<A, T: CheckedSum<A>>(self) -> Option<T>
+    where
+        Self: Iterator<Item = A>,
+        Self: Sized,
+    {
+        CheckedSum::checked_sum(self)
+    }
+
+    fn checked_product<A, T: CheckedProduct<A>>(self) -> Option<T>
+    where
+        Self: Iterator<Item = A>,
+        Self: Sized,
+    {
+        CheckedProduct::checked_product(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::float::FloatConst;
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, One, Zero};
 pub use crate::int::PrimInt;
-pub use crate::iter::{checked_product::CheckedProduct, checked_sum::CheckedSum};
+pub use crate::iter::{checked_product::CheckedProduct, checked_sum::CheckedSum, num_iter::NumIter};
 pub use crate::ops::checked::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use crate::float::FloatConst;
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, One, Zero};
 pub use crate::int::PrimInt;
+pub use crate::iter::{checked_product::CheckedProduct, checked_sum::CheckedSum};
 pub use crate::ops::checked::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub,
 };
@@ -56,6 +57,7 @@ pub mod cast;
 pub mod float;
 pub mod identities;
 pub mod int;
+pub mod iter;
 pub mod ops;
 pub mod pow;
 pub mod real;


### PR DESCRIPTION
Closes https://github.com/rust-num/num-traits/issues/250

This adds `CheckedSum` and `CheckedProduct` traits as well as blanket implementations for them. 

 It also adds `CheckedSumIter` and `CheckedProductIter` traits and blanket implementations for those as that provides a much more ergonomic interface, allowing you to do:


```rust
asserteq!(Some(42), [40,2].iter().checked_sum());
asserteq!(Some(42), [40,2].into_iter().checked_sum());
```