### PR TITLE
 Add read-only permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
       - staging
       - trying
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # 00:00 Sunday
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,9 @@ name: PR
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Fixes #262

As per the linked issue, this PR adds top-level read-only permissions to all GitHub workflows. This reduces the risk of a supply-chain attack on the project.