### PR TITLE
Allow `arithmetic_overflow` lint in a cast test

### DIFF
--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -241,6 +241,7 @@ fn cast_float_to_i128_edge_cases() {
 
 macro_rules! int_test_edge {
     ($f:ident -> { $($t:ident)+ } with $BigS:ident $BigU:ident ) => { $({
+        #[allow(arithmetic_overflow)] // https://github.com/rust-lang/rust/issues/109731
         fn test_edge() {
             dbg!("testing cast edge cases for {} -> {}", stringify!($f), stringify!($t));
 


### PR DESCRIPTION
The cast tests generate some code with branches that contain min/max
operations that would overflow if they were reachable. Recent rustc
changes have gotten more aggressive with const-propagation, causing that
code to trigger the deny-by-default `arithmetic_overflow` lint, but we
can explicitly allow it in this case.
