### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send us a [private vulnerability report](https://github.com/rust-num/num-traits/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single developer on a reasonable-effort basis. As such,
+I ask that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #268.

As described in the issue, this PR adds a security policy for the project to let people know how to responsibly report any vulnerabilities they might find.

Currently the policy suggests either an email or using GH's private reporting feature. I couldn't find an appropriate email, so I've left a placeholder for now.

The policy also has a 90-day timeline to remediate any vulnerabilities, which is pretty common.

If you want to make any changes (to the email/website or just use the private report or change the timeline, for example), let me know and I'll happily change the PR.