### PR TITLE
Add traits for `BITS`

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,0 +1,23 @@
+use core::{i128, i16, i32, i64, i8, isize};
+use core::{u128, u16, u32, u64, u8, usize};
+
+/// Numbers which have a specified number of bits.
+pub trait Bits {
+    /// Returns the size of the number in bits.
+    fn bits() -> u32;
+}
+
+macro_rules! bits_impl {
+    ( $($x:ident),* ) => (
+        $(
+            impl Bits for $x {
+                fn bits() -> u32 {
+                    $x::BITS
+                }
+            }
+        )*
+
+    );
+}
+
+bits_impl!(i128, i16, i32, i64, i8, isize, u128, u16, u32, u64, u8, usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use crate::bounds::Bounded;
 pub use crate::float::Float;
 pub use crate::float::FloatConst;
 // pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
+pub use crate::bits::Bits;
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, One, Zero};
 pub use crate::int::PrimInt;
@@ -51,6 +52,7 @@ pub use crate::sign::{abs, abs_sub, signum, Signed, Unsigned};
 #[macro_use]
 mod macros;
 
+pub mod bits;
 pub mod bounds;
 pub mod cast;
 pub mod float;


### PR DESCRIPTION
Adds a trait for getting the `BITS` constants e.g. [`u32::BITS`](https://doc.rust-lang.org/std/primitive.u32.html#associatedconstant.BITS).