### PR TITLE
Clarify `mul_add` Docs

### DIFF
--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -28,9 +28,9 @@ pub trait MulAdd<A = Self, B = Self> {
     fn mul_add(self, a: A, b: B) -> Self::Output;
 }
 
-/// The fused multiply-add assignment operation `self = (self * a) + b`
+/// The fused multiply-add assignment operation `*self = (*self * a) + b`
 pub trait MulAddAssign<A = Self, B = Self> {
-    /// Performs the fused multiply-add assignment operation `self = (self * a) + b`
+    /// Performs the fused multiply-add assignment operation `*self = (*self * a) + b`
     fn mul_add_assign(&mut self, a: A, b: B);
 }
 

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -24,13 +24,13 @@ pub trait MulAdd<A = Self, B = Self> {
     /// The resulting type after applying the fused multiply-add.
     type Output;
 
-    /// Performs the fused multiply-add operation.
+    /// Performs the fused multiply-add operation `(self * a) + b`
     fn mul_add(self, a: A, b: B) -> Self::Output;
 }
 
-/// The fused multiply-add assignment operation.
+/// The fused multiply-add assignment operation `self = (self * a) + b`
 pub trait MulAddAssign<A = Self, B = Self> {
-    /// Performs the fused multiply-add operation.
+    /// Performs the fused multiply-add assignment operation `self = (self * a) + b`
     fn mul_add_assign(&mut self, a: A, b: B);
 }
 


### PR DESCRIPTION
There is some great documentation on the `MulAdd` trait itself, but in cases where you only see the method doc (like hovering in an IDE), it's not clear what operation will take place.

Sometimes I remember what role each of the three numbers has, and even where the parens are, but either way it breaks my concentration having to drill into the impl to find the trait doc to double-check my assumptions.

Short of copy-pasting the excellent `MulAdd` trait doc everywhere, I think that just including the pseudocode describing the operation (as I've done in this PR) will go a long way in clarifying what it does.