### PR TITLE
Bugfix for text codeblock in documentation.

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -5,7 +5,7 @@ use core::ops::{Add, Mul};
 ///
 /// # Laws
 ///
-/// ```{.text}
+/// ```text
 /// a + 0 = a       ∀ a ∈ Self
 /// 0 + a = a       ∀ a ∈ Self
 /// ```
@@ -81,7 +81,7 @@ where
 ///
 /// # Laws
 ///
-/// ```{.text}
+/// ```text
 /// a * 1 = a       ∀ a ∈ Self
 /// 1 * a = a       ∀ a ∈ Self
 /// ```


### PR DESCRIPTION
Fixes https://github.com/rust-num/num-traits/issues/285 .
From what I have seen, the local output generated with `cargo +nightly doc --open` (rustc v1.74.0 nightly 203c57dbe) does not look differently than the most current one found here: https://docs.rs/num-traits/latest/num_traits/identities/trait.One.html

Propably related to https://github.com/rust-lang/rust/pull/110800 ? If it is, then the issue might be fixed soon and this PR should be ignored..