### PR TITLE
Implement IntoIterator<Item=u8> for NumBytes

### DIFF
--- a/src/ops/bytes.rs
+++ b/src/ops/bytes.rs
@@ -16,6 +16,7 @@ pub trait NumBytes:
     + Hash
     + Borrow<[u8]>
     + BorrowMut<[u8]>
+    + IntoIterator<Item = u8>
 {
 }
 
@@ -30,6 +31,7 @@ impl<T> NumBytes for T where
         + Hash
         + Borrow<[u8]>
         + BorrowMut<[u8]>
+        + IntoIterator<Item = u8>
         + ?Sized
 {
 }


### PR DESCRIPTION
This PR implements `IntoIterator<Item = u8>` for `NumBytes`, since the `AsRef` and `Borrow` traits for `NumBytes` will have trouble with lifetime as it borrows the array.

An actual usage of this trait is when I want to convert a list of integers into bytes (i.e. flatten the generated bytes array for each integer):

```rust
fn flatten_to_bytes_array<I: ToBytes>(integers: &[I]) -> Vec<u8> {
    integers
        .iter()
        .map(|integer| integer.to_ne_bytes().into_iter())
        .flatten()
        .collect()
}
```

However, if I replace the `into_iter` with `as_ref()`, the borrow checker will deny the compilation since the lifetime of the array generated in `to_ne_bytes()` cannot live long enough. The workaround here is just `as_ref().to_vec()`, which involves additional heap allocations.