### PR TITLE
`TotalOrder` trait for floating point numbers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
           1.44.0, # has_to_int_unchecked
           1.46.0, # has_leading_trailing_ones
           1.53.0, # has_is_subnormal
+          1.62.0, # has_total_cmp
           stable,
           beta,
           nightly,

--- a/bors.toml
+++ b/bors.toml
@@ -6,6 +6,7 @@ status = [
   "Test (1.44.0)",
   "Test (1.46.0)",
   "Test (1.53.0)",
+  "Test (1.62.0)",
   "Test (stable)",
   "Test (beta)",
   "Test (nightly)",

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         ac.emit_expression_cfg("1f64.copysign(-1f64)", "has_copysign");
     }
     ac.emit_expression_cfg("1f64.is_subnormal()", "has_is_subnormal");
+    ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp");
 
     ac.emit_expression_cfg("1u32.to_ne_bytes()", "has_int_to_from_bytes");
     ac.emit_expression_cfg("3.14f64.to_ne_bytes()", "has_float_to_from_bytes");

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.31.0 1.35.0 1.37.0 1.38.0 1.44.0 1.46.0 1.53.0 stable beta nightly; do
+for version in 1.31.0 1.35.0 1.37.0 1.38.0 1.44.0 1.46.0 1.53.0 1.62.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,3 +1,4 @@
+use core::cmp::Ordering;
 use core::num::FpCategory;
 use core::ops::{Add, Div, Neg};
 
@@ -2246,30 +2247,31 @@ pub trait TotalOrder {
     /// # Examples
     /// ```
     /// use num_traits::float::TotalOrder;
+    /// use std::cmp::Ordering;
     /// use std::{f32, f64};
     ///
     /// fn check_eq<T: TotalOrder>(x: T, y: T) {
-    ///     assert_eq!(x.total_cmp(&y), std::cmp::Ordering::Equal);
+    ///     assert_eq!(x.total_cmp(&y), Ordering::Equal);
     /// }
     ///
     /// check_eq(f64::NAN, f64::NAN);
     /// check_eq(f32::NAN, f32::NAN);
     ///
     /// fn check_lt<T: TotalOrder>(x: T, y: T) {
-    ///     assert_eq!(x.total_cmp(&y), std::cmp::Ordering::Less);
+    ///     assert_eq!(x.total_cmp(&y), Ordering::Less);
     /// }
     ///
     /// check_lt(-f64::NAN, f64::NAN);
     /// check_lt(f64::INFINITY, f64::NAN);
     /// check_lt(-0.0_f64, 0.0_f64);
     /// ```
-    fn total_cmp(&self, other: &Self) -> std::cmp::Ordering;
+    fn total_cmp(&self, other: &Self) -> Ordering;
 }
 macro_rules! totalorder_impl {
     ($T:ident) => {
         impl TotalOrder for $T {
             #[inline]
-            fn total_cmp(&self, other: &Self) -> std::cmp::Ordering {
+            fn total_cmp(&self, other: &Self) -> Ordering {
                 Self::total_cmp(&self, other)
             }
         }
@@ -2413,14 +2415,17 @@ mod tests {
     #[test]
     fn total_cmp() {
         use crate::float::{Float, TotalOrder};
+        use core::cmp::Ordering;
+        use core::{f32, f64};
+
         fn check_eq<T: Float + TotalOrder>(x: T, y: T) {
-            assert_eq!(x.total_cmp(&y), std::cmp::Ordering::Equal);
+            assert_eq!(x.total_cmp(&y), Ordering::Equal);
         }
         fn check_lt<T: Float + TotalOrder>(x: T, y: T) {
-            assert_eq!(x.total_cmp(&y), std::cmp::Ordering::Less);
+            assert_eq!(x.total_cmp(&y), Ordering::Less);
         }
         fn check_gt<T: Float + TotalOrder>(x: T, y: T) {
-            assert_eq!(x.total_cmp(&y), std::cmp::Ordering::Greater);
+            assert_eq!(x.total_cmp(&y), Ordering::Greater);
         }
 
         check_eq(f64::NAN, f64::NAN);

--- a/src/float.rs
+++ b/src/float.rs
@@ -2434,20 +2434,20 @@ mod tests {
         check_lt(-0.0_f64, 0.0_f64);
         check_lt(-0.0_f32, 0.0_f32);
 
-        let s_nan = unsafe { std::mem::transmute::<u64, f64>(0x7ff4000000000000) };
-        let q_nan = unsafe { std::mem::transmute::<u64, f64>(0x7ff8000000000000) };
+        let s_nan = f64::from_bits(0x7ff4000000000000);
+        let q_nan = f64::from_bits(0x7ff8000000000000);
         check_lt(s_nan, q_nan);
 
-        let neg_s_nan = unsafe { std::mem::transmute::<u64, f64>(0xfff4000000000000) };
-        let neg_q_nan = unsafe { std::mem::transmute::<u64, f64>(0xfff8000000000000) };
+        let neg_s_nan = f64::from_bits(0xfff4000000000000);
+        let neg_q_nan = f64::from_bits(0xfff8000000000000);
         check_lt(neg_q_nan, neg_s_nan);
 
-        let s_nan = unsafe { std::mem::transmute::<u32, f32>(0x7fa00000) };
-        let q_nan = unsafe { std::mem::transmute::<u32, f32>(0x7fc00000) };
+        let s_nan = f32::from_bits(0x7fa00000);
+        let q_nan = f32::from_bits(0x7fc00000);
         check_lt(s_nan, q_nan);
 
-        let neg_s_nan = unsafe { std::mem::transmute::<u32, f32>(0xffa00000) };
-        let neg_q_nan = unsafe { std::mem::transmute::<u32, f32>(0xffc00000) };
+        let neg_s_nan = f32::from_bits(0xffa00000);
+        let neg_q_nan = f32::from_bits(0xffc00000);
         check_lt(neg_q_nan, neg_s_nan);
 
         check_lt(-f64::NAN, f64::NEG_INFINITY);

--- a/src/float.rs
+++ b/src/float.rs
@@ -2448,21 +2448,26 @@ mod tests {
         check_lt(-0.0_f64, 0.0_f64);
         check_lt(-0.0_f32, 0.0_f32);
 
-        let s_nan = f64::from_bits(0x7ff4000000000000);
-        let q_nan = f64::from_bits(0x7ff8000000000000);
-        check_lt(s_nan, q_nan);
+        // x87 registers don't preserve the exact value of signaling NaN:
+        // https://github.com/rust-lang/rust/issues/115567
+        #[cfg(not(target_arch = "x86"))]
+        {
+            let s_nan = f64::from_bits(0x7ff4000000000000);
+            let q_nan = f64::from_bits(0x7ff8000000000000);
+            check_lt(s_nan, q_nan);
 
-        let neg_s_nan = f64::from_bits(0xfff4000000000000);
-        let neg_q_nan = f64::from_bits(0xfff8000000000000);
-        check_lt(neg_q_nan, neg_s_nan);
+            let neg_s_nan = f64::from_bits(0xfff4000000000000);
+            let neg_q_nan = f64::from_bits(0xfff8000000000000);
+            check_lt(neg_q_nan, neg_s_nan);
 
-        let s_nan = f32::from_bits(0x7fa00000);
-        let q_nan = f32::from_bits(0x7fc00000);
-        check_lt(s_nan, q_nan);
+            let s_nan = f32::from_bits(0x7fa00000);
+            let q_nan = f32::from_bits(0x7fc00000);
+            check_lt(s_nan, q_nan);
 
-        let neg_s_nan = f32::from_bits(0xffa00000);
-        let neg_q_nan = f32::from_bits(0xffc00000);
-        check_lt(neg_q_nan, neg_s_nan);
+            let neg_s_nan = f32::from_bits(0xffa00000);
+            let neg_q_nan = f32::from_bits(0xffc00000);
+            check_lt(neg_q_nan, neg_s_nan);
+        }
 
         check_lt(-f64::NAN, f64::NEG_INFINITY);
         check_gt(1.0_f64, -f64::NAN);

--- a/src/float.rs
+++ b/src/float.rs
@@ -2414,17 +2414,17 @@ mod tests {
 
     #[test]
     fn total_cmp() {
-        use crate::float::{Float, TotalOrder};
+        use crate::float::TotalOrder;
         use core::cmp::Ordering;
         use core::{f32, f64};
 
-        fn check_eq<T: Float + TotalOrder>(x: T, y: T) {
+        fn check_eq<T: TotalOrder>(x: T, y: T) {
             assert_eq!(x.total_cmp(&y), Ordering::Equal);
         }
-        fn check_lt<T: Float + TotalOrder>(x: T, y: T) {
+        fn check_lt<T: TotalOrder>(x: T, y: T) {
             assert_eq!(x.total_cmp(&y), Ordering::Less);
         }
-        fn check_gt<T: Float + TotalOrder>(x: T, y: T) {
+        fn check_gt<T: TotalOrder>(x: T, y: T) {
             assert_eq!(x.total_cmp(&y), Ordering::Greater);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ pub use crate::bounds::Bounded;
 #[cfg(any(feature = "std", feature = "libm"))]
 pub use crate::float::Float;
 pub use crate::float::FloatConst;
-pub use crate::float::TotalOrder;
 // pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, One, Zero};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use crate::bounds::Bounded;
 #[cfg(any(feature = "std", feature = "libm"))]
 pub use crate::float::Float;
 pub use crate::float::FloatConst;
+pub use crate::float::TotalOrder;
 // pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
 pub use crate::identities::{one, zero, One, Zero};


### PR DESCRIPTION
Define an orthogonal trait which corresponds to the `totalOrder` predicate the IEEE 754 (2008 revision) floating point standard.

In order to maintain coherence, the bounds on `TotalOrder` should most likely be `TotalOrder: Float` (or `TotalOrder: FloatCore`).  Without type constraints, `TotalOrder` could be defined on, well, anything. Though slightly ugly, one way to deal with this is to define two traits, `TotalOrderCore: FloatCore` and `TotalOrder: Float`.  On the other hand, `Inv` has no such constraints (due to the possibility of a meaningful implementation on rational numbers). If the crate designers could weigh in on whether to introduce constraints, that would be helpful.

Resolves: [issue#256](https://github.com/rust-num/num-traits/issues/256)