### PR TITLE
feat: implement first naive version of induction

### DIFF
--- a/src/induction.rs
+++ b/src/induction.rs
@@ -1,0 +1,74 @@
+use core::ops::Add;
+
+use crate::{One, Zero};
+
+pub trait Induction: Zero + One {
+    fn nth<const N: usize>() -> Self;
+}
+
+impl<T> Induction for T
+where
+    T: Zero + One + Add<Self>,
+{
+    // I wasn't able to implement this with const-ness at the time of initially writing this.
+    // Please feel free to update the code to something else.
+    //
+    // I was also tempted to write this recursively as it looks prettier, but rust doesn't optimize
+    // tail calls in debug mode. This means we overflow the stack really quickly in debug mode. So
+    // anyone using this trait and compiling in debug would potentially run into panics due to
+    // overflow
+    fn nth<const N: usize>() -> Self {
+        let mut res = T::zero();
+        for _ in 0..N {
+            res = res + T::one();
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+trait TestRequirements: Induction + std::fmt::Debug + PartialEq + crate::NumCast {}
+#[cfg(test)]
+impl<T: Induction + std::fmt::Debug + PartialEq + crate::NumCast> TestRequirements for T {}
+
+#[cfg(test)]
+fn assert_eq_nth_n<S: TestRequirements, const N: usize>() {
+    assert_eq!(
+        <S as crate::NumCast>::from(N)
+            .unwrap_or_else(|| panic!("Couldn't convert {N} to {}", std::any::type_name::<S>())),
+        S::nth::<N>()
+    );
+}
+
+#[cfg(test)]
+fn nth_t<T: TestRequirements>() {
+    assert_eq_nth_n::<T, 0>();
+    assert_eq_nth_n::<T, 1>();
+    assert_eq_nth_n::<T, 2>();
+    // biggest number that's safe for all primitive types
+    assert_eq_nth_n::<T, 127>();
+}
+
+#[test]
+fn basic_nth_all_types() {
+    nth_t::<i8>();
+    nth_t::<i16>();
+    nth_t::<i32>();
+    nth_t::<i64>();
+    nth_t::<isize>();
+
+    nth_t::<u8>();
+    nth_t::<u16>();
+    nth_t::<u32>();
+    nth_t::<u64>();
+    nth_t::<usize>();
+
+    nth_t::<f32>();
+    nth_t::<f64>();
+}
+
+#[test]
+#[should_panic]
+fn nth_overflow() {
+    i8::nth::<128>();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod bounds;
 pub mod cast;
 pub mod float;
 pub mod identities;
+pub mod induction;
 pub mod int;
 pub mod ops;
 pub mod pow;


### PR DESCRIPTION
I see a lot of crates using things like

```rust
let two = T::one() + T::one();
```

I've seen this multiple times in [geo](https://github.com/georust/geo) while working on different areas there. This PR implements a trait `Induction` which has a method `nth` which can be used as follows

```rust
let two = T::nth<2>();
let five = T::nth<5>();
```

I'm not sure if you think that this abstraction is worth it. I personally feel this removes a bit of boilerplate code and also reads nicer. 

This PR is open for review, but please don't merge it yet as I'll add some more docs + tests at some point in the near future.