### PR TITLE
Add `ConstZero` and `ConstOne` traits

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -38,20 +38,19 @@ pub trait ZeroConstant: Zero {
     const ZERO: Self;
 }
 
-impl<T: ZeroConstant + PartialEq> Zero for T {
-    #[inline(always)]
-    fn zero() -> T {
-        Self::ZERO
-    }
-
-    #[inline(always)]
-    fn is_zero(&self) -> bool {
-        self == &Self::ZERO
-    }
-}
-
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
+        impl Zero for $t {
+            #[inline]
+            fn zero() -> $t {
+                $v
+            }
+            #[inline]
+            fn is_zero(&self) -> bool {
+                *self == $v
+            }
+        }
+
         impl ZeroConstant for $t {
             const ZERO: Self = $v;
         }
@@ -90,6 +89,13 @@ where
     fn zero() -> Self {
         Wrapping(T::zero())
     }
+}
+
+impl<T: ZeroConstant> ZeroConstant for Wrapping<T>
+where
+    Wrapping<T>: Add<Output = Wrapping<T>>,
+{
+    const ZERO: Self = Self(T::ZERO);
 }
 
 /// Defines a multiplicative identity element for `Self`.
@@ -140,20 +146,19 @@ pub trait OneConstant: One {
     const ONE: Self;
 }
 
-impl<T: OneConstant + PartialEq> One for T {
-    #[inline(always)]
-    fn one() -> T {
-        Self::ONE
-    }
-
-    #[inline(always)]
-    fn is_one(&self) -> bool {
-        self == &Self::ONE
-    }
-}
-
 macro_rules! one_impl {
     ($t:ty, $v:expr) => {
+        impl One for $t {
+            #[inline]
+            fn one() -> $t {
+                $v
+            }
+            #[inline]
+            fn is_one(&self) -> bool {
+                *self == $v
+            }
+        }
+
         impl OneConstant for $t {
             const ONE: Self = $v;
         }
@@ -188,6 +193,13 @@ where
     fn one() -> Self {
         Wrapping(T::one())
     }
+}
+
+impl<T: OneConstant> OneConstant for Wrapping<T>
+where
+    Wrapping<T>: Mul<Output = Wrapping<T>>,
+{
+    const ONE: Self = Self(T::ONE);
 }
 
 // Some helper functions provided for backwards compatibility.

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -135,9 +135,6 @@ pub trait One: Sized + Mul<Self, Output = Self> {
 
 /// Defines an associated constant representing the multiplicative identity
 /// element for `Self`.
-///
-/// Types which impl both this trait and [`PartialEq`] will receive a blanket
-/// impl of the [`One`] trait.
 pub trait ConstOne: One {
     /// The multiplicative identity element of `Self`, `1`.
     const ONE: Self;

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -30,9 +30,6 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
 
 /// Defines an associated constant representing the additive identity element
 /// for `Self`.
-///
-/// Types which impl both this trait and [`PartialEq`] will receive a blanket
-/// impl of the [`Zero`] trait.
 pub trait ConstZero: Zero {
     /// The additive identity element of `Self`, `0`.
     const ZERO: Self;

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -33,7 +33,7 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
 ///
 /// Types which impl both this trait and [`PartialEq`] will receive a blanket
 /// impl of the [`Zero`] trait.
-pub trait ZeroConstant: Zero {
+pub trait ConstZero: Zero {
     /// The additive identity element of `Self`, `0`.
     const ZERO: Self;
 }
@@ -51,7 +51,7 @@ macro_rules! zero_impl {
             }
         }
 
-        impl ZeroConstant for $t {
+        impl ConstZero for $t {
             const ZERO: Self = $v;
         }
     };
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<T: ZeroConstant> ZeroConstant for Wrapping<T>
+impl<T: ConstZero> ConstZero for Wrapping<T>
 where
     Wrapping<T>: Add<Output = Wrapping<T>>,
 {
@@ -141,7 +141,7 @@ pub trait One: Sized + Mul<Self, Output = Self> {
 ///
 /// Types which impl both this trait and [`PartialEq`] will receive a blanket
 /// impl of the [`One`] trait.
-pub trait OneConstant: One {
+pub trait ConstOne: One {
     /// The multiplicative identity element of `Self`, `1`.
     const ONE: Self;
 }
@@ -159,7 +159,7 @@ macro_rules! one_impl {
             }
         }
 
-        impl OneConstant for $t {
+        impl ConstOne for $t {
             const ONE: Self = $v;
         }
     };
@@ -195,7 +195,7 @@ where
     }
 }
 
-impl<T: OneConstant> OneConstant for Wrapping<T>
+impl<T: ConstOne> ConstOne for Wrapping<T>
 where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -28,17 +28,32 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn is_zero(&self) -> bool;
 }
 
+/// Defines an associated constant representing the additive identity element
+/// for `Self`.
+///
+/// Types which impl both this trait and [`PartialEq`] will receive a blanket
+/// impl of the [`Zero`] trait.
+pub trait ZeroConstant: Zero {
+    /// The additive identity element of `Self`, `0`.
+    const ZERO: Self;
+}
+
+impl<T: ZeroConstant + PartialEq> Zero for T {
+    #[inline(always)]
+    fn zero() -> T {
+        Self::ZERO
+    }
+
+    #[inline(always)]
+    fn is_zero(&self) -> bool {
+        self == &Self::ZERO
+    }
+}
+
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
-        impl Zero for $t {
-            #[inline]
-            fn zero() -> $t {
-                $v
-            }
-            #[inline]
-            fn is_zero(&self) -> bool {
-                *self == $v
-            }
+        impl ZeroConstant for $t {
+            const ZERO: Self = $v;
         }
     };
 }
@@ -115,17 +130,32 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     }
 }
 
+/// Defines an associated constant representing the multiplicative identity
+/// element for `Self`.
+///
+/// Types which impl both this trait and [`PartialEq`] will receive a blanket
+/// impl of the [`One`] trait.
+pub trait OneConstant: One {
+    /// The multiplicative identity element of `Self`, `1`.
+    const ONE: Self;
+}
+
+impl<T: OneConstant + PartialEq> One for T {
+    #[inline(always)]
+    fn one() -> T {
+        Self::ONE
+    }
+
+    #[inline(always)]
+    fn is_one(&self) -> bool {
+        self == &Self::ONE
+    }
+}
+
 macro_rules! one_impl {
     ($t:ty, $v:expr) => {
-        impl One for $t {
-            #[inline]
-            fn one() -> $t {
-                $v
-            }
-            #[inline]
-            fn is_one(&self) -> bool {
-                *self == $v
-            }
+        impl OneConstant for $t {
+            const ONE: Self = $v;
         }
     };
 }

--- a/src/identities.rs
+++ b/src/identities.rs
@@ -92,7 +92,7 @@ impl<T: ConstZero> ConstZero for Wrapping<T>
 where
     Wrapping<T>: Add<Output = Wrapping<T>>,
 {
-    const ZERO: Self = Self(T::ZERO);
+    const ZERO: Self = Wrapping(T::ZERO);
 }
 
 /// Defines a multiplicative identity element for `Self`.
@@ -193,7 +193,7 @@ impl<T: ConstOne> ConstOne for Wrapping<T>
 where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {
-    const ONE: Self = Self(T::ONE);
+    const ONE: Self = Wrapping(T::ONE);
 }
 
 // Some helper functions provided for backwards compatibility.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::float::Float;
 pub use crate::float::FloatConst;
 // pub use real::{FloatCore, Real}; // NOTE: Don't do this, it breaks `use num_traits::*;`.
 pub use crate::cast::{cast, AsPrimitive, FromPrimitive, NumCast, ToPrimitive};
-pub use crate::identities::{one, zero, One, Zero};
+pub use crate::identities::{one, zero, ConstOne, ConstZero, One, Zero};
 pub use crate::int::PrimInt;
 pub use crate::ops::bytes::{FromBytes, ToBytes};
 pub use crate::ops::checked::{


### PR DESCRIPTION
Adds traits which are alternatives to the more dynamic `Zero`/`One` traits which are useful for stack-allocated types where it's possible to define constant values for zero/one.

~~`ZeroConstant`~~ `ConstZero` bounds on `Zero` as a supertrait, and ~~`OneConstant`~~ `ConstOne` on `One`, allowing them to be used as drop-in replacements.

~~When a type also impls `PartialEq`, then `ZeroConstant` also provides a blanket impl of `Zero`, and likewise for `OneConstant`/`One`, making it simple for stack-allocated integers to impl these traits as an alternative to `Zero`/`One` while still remaining fully compatible.~~ (Edit: removed)

~~The internal impls of `Zero`/`One` on the numeric primitive types have been changed to use these traits, which should be a fully backwards-compatible change.~~ (Edit: removed)

Alternative to #276.