### PR TITLE
Use namespaced-features to safely bump to MSRV 1.60

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.31.0, # MSRV
-          1.35.0, # has_copysign
-          1.37.0, # has_reverse_bits
-          1.38.0, # has_div_euclid
-          1.44.0, # has_to_int_unchecked
-          1.46.0, # has_leading_trailing_ones
-          1.53.0, # has_is_subnormal
+          1.60.0, # MSRV
           1.62.0, # has_total_cmp
           stable,
           beta,

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*"]
 edition = "2018"
-rust-version = "1.31"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 features = ["std"]
@@ -24,6 +24,7 @@ libm = { version = "0.2.0", optional = true }
 
 [features]
 default = ["std"]
+libm = ["dep:libm"]
 std = []
 
 # vestigial features, now always in effect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.2.18"
 readme = "README.md"
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-traits.svg)](https://crates.io/crates/num-traits)
 [![documentation](https://docs.rs/num-traits/badge.svg)](https://docs.rs/num-traits)
-[![minimum rustc 1.31](https://img.shields.io/badge/rustc-1.31+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.60](https://img.shields.io/badge/rustc-1.60+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/rust-num/num-traits/workflows/master/badge.svg)](https://github.com/rust-num/num-traits/actions)
 
 Numeric traits for generic mathematics in Rust.
@@ -40,7 +40,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-traits` crate is tested for rustc 1.31 and greater.
+The `num-traits` crate is tested for rustc 1.60 and greater.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ fn main() {
 
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
 
-    ac.emit_expression_cfg("1u32.to_ne_bytes()", "has_int_to_from_bytes");
     ac.emit_expression_cfg("3.14f64.to_ne_bytes()", "has_float_to_from_bytes");
 
     autocfg::rerun_path("build.rs");

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::env;
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg("1u32.reverse_bits()", "has_reverse_bits");
     ac.emit_expression_cfg("1u32.trailing_ones()", "has_leading_trailing_ones");
     ac.emit_expression_cfg("1u32.div_euclid(1u32)", "has_div_euclid");
 

--- a/build.rs
+++ b/build.rs
@@ -3,11 +3,6 @@ use std::env;
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg(
-        "unsafe { 1f64.to_int_unchecked::<i32>() }",
-        "has_to_int_unchecked",
-    );
-
     ac.emit_expression_cfg("1u32.reverse_bits()", "has_reverse_bits");
     ac.emit_expression_cfg("1u32.trailing_ones()", "has_leading_trailing_ones");
     ac.emit_expression_cfg("1u32.div_euclid(1u32)", "has_div_euclid");

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg("1f64.is_subnormal()", "has_is_subnormal");
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp");
 
     ac.emit_expression_cfg("1u32.to_ne_bytes()", "has_int_to_from_bytes");

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::env;
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg("1u32.trailing_ones()", "has_leading_trailing_ones");
     ac.emit_expression_cfg("1u32.div_euclid(1u32)", "has_div_euclid");
 
     if env::var_os("CARGO_FEATURE_STD").is_some() {

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,5 @@ fn main() {
 
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
 
-    ac.emit_expression_cfg("3.14f64.to_ne_bytes()", "has_float_to_from_bytes");
-
     autocfg::rerun_path("build.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,6 @@ use std::env;
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg("1u32.div_euclid(1u32)", "has_div_euclid");
-
     if env::var_os("CARGO_FEATURE_STD").is_some() {
         ac.emit_expression_cfg("1f64.copysign(-1f64)", "has_copysign");
     }

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,6 @@
-use std::env;
-
 fn main() {
     let ac = autocfg::new();
 
-    if env::var_os("CARGO_FEATURE_STD").is_some() {
-        ac.emit_expression_cfg("1f64.copysign(-1f64)", "has_copysign");
-    }
     ac.emit_expression_cfg("1f64.is_subnormal()", "has_is_subnormal");
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp");
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     let ac = autocfg::new();
 
-    ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp");
+    ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
 
     ac.emit_expression_cfg("1u32.to_ne_bytes()", "has_int_to_from_bytes");
     ac.emit_expression_cfg("3.14f64.to_ne_bytes()", "has_float_to_from_bytes");

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.31.0 1.35.0 1.37.0 1.38.0 1.44.0 1.46.0 1.53.0 1.62.0 stable beta nightly; do
+for version in 1.60.0 1.62.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=num-traits
-MSRV=1.31
+MSRV=1.60
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -31,9 +31,6 @@ FEATURES=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 cargo generate-lockfile
-
-# libm 0.2.6 started using {float}::EPSILON
-check_version 1.43 || cargo update -p libm --precise 0.2.5
 
 set -x
 

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -277,19 +277,11 @@ macro_rules! impl_to_primitive_float_to_float {
     )*}
 }
 
-#[cfg(has_to_int_unchecked)]
 macro_rules! float_to_int_unchecked {
     // SAFETY: Must not be NaN or infinite; must be representable as the integer after truncating.
     // We already checked that the float is in the exclusive range `(MIN-1, MAX+1)`.
     ($float:expr => $int:ty) => {
         unsafe { $float.to_int_unchecked::<$int>() }
-    };
-}
-
-#[cfg(not(has_to_int_unchecked))]
-macro_rules! float_to_int_unchecked {
-    ($float:expr => $int:ty) => {
-        $float as $int
     };
 }
 

--- a/src/float.rs
+++ b/src/float.rs
@@ -1944,10 +1944,6 @@ macro_rules! float_impl_std {
                 Self::asinh(self) -> Self;
                 Self::acosh(self) -> Self;
                 Self::atanh(self) -> Self;
-            }
-
-            #[cfg(has_copysign)]
-            forward! {
                 Self::copysign(self, sign: Self) -> Self;
             }
 

--- a/src/float.rs
+++ b/src/float.rs
@@ -790,6 +790,7 @@ impl FloatCore for f32 {
         Self::is_infinite(self) -> bool;
         Self::is_finite(self) -> bool;
         Self::is_normal(self) -> bool;
+        Self::is_subnormal(self) -> bool;
         Self::classify(self) -> FpCategory;
         Self::is_sign_positive(self) -> bool;
         Self::is_sign_negative(self) -> bool;
@@ -798,11 +799,6 @@ impl FloatCore for f32 {
         Self::recip(self) -> Self;
         Self::to_degrees(self) -> Self;
         Self::to_radians(self) -> Self;
-    }
-
-    #[cfg(has_is_subnormal)]
-    forward! {
-        Self::is_subnormal(self) -> bool;
     }
 
     #[cfg(feature = "std")]
@@ -855,6 +851,7 @@ impl FloatCore for f64 {
         Self::is_infinite(self) -> bool;
         Self::is_finite(self) -> bool;
         Self::is_normal(self) -> bool;
+        Self::is_subnormal(self) -> bool;
         Self::classify(self) -> FpCategory;
         Self::is_sign_positive(self) -> bool;
         Self::is_sign_negative(self) -> bool;
@@ -863,11 +860,6 @@ impl FloatCore for f64 {
         Self::recip(self) -> Self;
         Self::to_degrees(self) -> Self;
         Self::to_radians(self) -> Self;
-    }
-
-    #[cfg(has_is_subnormal)]
-    forward! {
-        Self::is_subnormal(self) -> bool;
     }
 
     #[cfg(feature = "std")]
@@ -1901,6 +1893,7 @@ macro_rules! float_impl_std {
                 Self::is_infinite(self) -> bool;
                 Self::is_finite(self) -> bool;
                 Self::is_normal(self) -> bool;
+                Self::is_subnormal(self) -> bool;
                 Self::classify(self) -> FpCategory;
                 Self::floor(self) -> Self;
                 Self::ceil(self) -> Self;
@@ -1946,11 +1939,6 @@ macro_rules! float_impl_std {
                 Self::atanh(self) -> Self;
                 Self::copysign(self, sign: Self) -> Self;
             }
-
-            #[cfg(has_is_subnormal)]
-            forward! {
-                Self::is_subnormal(self) -> bool;
-            }
         }
     };
 }
@@ -1989,6 +1977,7 @@ macro_rules! float_impl_libm {
             Self::is_infinite(self) -> bool;
             Self::is_finite(self) -> bool;
             Self::is_normal(self) -> bool;
+            Self::is_subnormal(self) -> bool;
             Self::classify(self) -> FpCategory;
             Self::is_sign_positive(self) -> bool;
             Self::is_sign_negative(self) -> bool;
@@ -1997,11 +1986,6 @@ macro_rules! float_impl_libm {
             Self::recip(self) -> Self;
             Self::to_degrees(self) -> Self;
             Self::to_radians(self) -> Self;
-        }
-
-        #[cfg(has_is_subnormal)]
-        forward! {
-            Self::is_subnormal(self) -> bool;
         }
 
         forward! {

--- a/src/int.rs
+++ b/src/int.rs
@@ -404,7 +404,6 @@ macro_rules! prim_int_impl {
                 <$T>::count_zeros(self)
             }
 
-            #[cfg(has_leading_trailing_ones)]
             #[inline]
             fn leading_ones(self) -> u32 {
                 <$T>::leading_ones(self)
@@ -415,7 +414,6 @@ macro_rules! prim_int_impl {
                 <$T>::leading_zeros(self)
             }
 
-            #[cfg(has_leading_trailing_ones)]
             #[inline]
             fn trailing_ones(self) -> u32 {
                 <$T>::trailing_ones(self)

--- a/src/int.rs
+++ b/src/int.rs
@@ -461,7 +461,6 @@ macro_rules! prim_int_impl {
                 <$T>::swap_bytes(self)
             }
 
-            #[cfg(has_reverse_bits)]
             #[inline]
             fn reverse_bits(self) -> Self {
                 <$T>::reverse_bits(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-traits` crate is tested for rustc 1.31 and greater.
+//! The `num-traits` crate is tested for rustc 1.60 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num-traits/0.2")]
 #![deny(unconditional_recursion)]

--- a/src/ops/bytes.rs
+++ b/src/ops/bytes.rs
@@ -150,7 +150,6 @@ pub trait FromBytes: Sized {
 
 macro_rules! float_to_from_bytes_impl {
     ($T:ty, $L:expr) => {
-        #[cfg(has_float_to_from_bytes)]
         impl ToBytes for $T {
             type Bytes = [u8; $L];
 
@@ -170,7 +169,6 @@ macro_rules! float_to_from_bytes_impl {
             }
         }
 
-        #[cfg(has_float_to_from_bytes)]
         impl FromBytes for $T {
             type Bytes = [u8; $L];
 
@@ -187,46 +185,6 @@ macro_rules! float_to_from_bytes_impl {
             #[inline]
             fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
                 <$T>::from_ne_bytes(*bytes)
-            }
-        }
-
-        #[cfg(not(has_float_to_from_bytes))]
-        impl ToBytes for $T {
-            type Bytes = [u8; $L];
-
-            #[inline]
-            fn to_be_bytes(&self) -> Self::Bytes {
-                ToBytes::to_be_bytes(&self.to_bits())
-            }
-
-            #[inline]
-            fn to_le_bytes(&self) -> Self::Bytes {
-                ToBytes::to_le_bytes(&self.to_bits())
-            }
-
-            #[inline]
-            fn to_ne_bytes(&self) -> Self::Bytes {
-                ToBytes::to_ne_bytes(&self.to_bits())
-            }
-        }
-
-        #[cfg(not(has_float_to_from_bytes))]
-        impl FromBytes for $T {
-            type Bytes = [u8; $L];
-
-            #[inline]
-            fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-                Self::from_bits(FromBytes::from_be_bytes(bytes))
-            }
-
-            #[inline]
-            fn from_le_bytes(bytes: &Self::Bytes) -> Self {
-                Self::from_bits(FromBytes::from_le_bytes(bytes))
-            }
-
-            #[inline]
-            fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
-                Self::from_bits(FromBytes::from_ne_bytes(bytes))
             }
         }
     };

--- a/src/ops/bytes.rs
+++ b/src/ops/bytes.rs
@@ -2,8 +2,6 @@ use core::borrow::{Borrow, BorrowMut};
 use core::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use core::fmt::Debug;
 use core::hash::Hash;
-#[cfg(not(has_int_to_from_bytes))]
-use core::mem::transmute;
 
 pub trait NumBytes:
     Debug
@@ -236,7 +234,6 @@ macro_rules! float_to_from_bytes_impl {
 
 macro_rules! int_to_from_bytes_impl {
     ($T:ty, $L:expr) => {
-        #[cfg(has_int_to_from_bytes)]
         impl ToBytes for $T {
             type Bytes = [u8; $L];
 
@@ -256,7 +253,6 @@ macro_rules! int_to_from_bytes_impl {
             }
         }
 
-        #[cfg(has_int_to_from_bytes)]
         impl FromBytes for $T {
             type Bytes = [u8; $L];
 
@@ -273,46 +269,6 @@ macro_rules! int_to_from_bytes_impl {
             #[inline]
             fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
                 <$T>::from_ne_bytes(*bytes)
-            }
-        }
-
-        #[cfg(not(has_int_to_from_bytes))]
-        impl ToBytes for $T {
-            type Bytes = [u8; $L];
-
-            #[inline]
-            fn to_be_bytes(&self) -> Self::Bytes {
-                <$T as ToBytes>::to_ne_bytes(&<$T>::to_be(*self))
-            }
-
-            #[inline]
-            fn to_le_bytes(&self) -> Self::Bytes {
-                <$T as ToBytes>::to_ne_bytes(&<$T>::to_le(*self))
-            }
-
-            #[inline]
-            fn to_ne_bytes(&self) -> Self::Bytes {
-                unsafe { transmute(*self) }
-            }
-        }
-
-        #[cfg(not(has_int_to_from_bytes))]
-        impl FromBytes for $T {
-            type Bytes = [u8; $L];
-
-            #[inline]
-            fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-                Self::from_be(<Self as FromBytes>::from_ne_bytes(bytes))
-            }
-
-            #[inline]
-            fn from_le_bytes(bytes: &Self::Bytes) -> Self {
-                Self::from_le(<Self as FromBytes>::from_ne_bytes(bytes))
-            }
-
-            #[inline]
-            fn from_ne_bytes(bytes: &Self::Bytes) -> Self {
-                unsafe { transmute(*bytes) }
             }
         }
     };

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -71,7 +71,6 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
 
 macro_rules! euclid_forward_impl {
     ($($t:ty)*) => {$(
-        #[cfg(has_div_euclid)]
         impl Euclid for $t {
             #[inline]
             fn div_euclid(&self, v: &$t) -> Self {
@@ -86,64 +85,13 @@ macro_rules! euclid_forward_impl {
     )*}
 }
 
-macro_rules! euclid_int_impl {
-    ($($t:ty)*) => {$(
-        euclid_forward_impl!($t);
+euclid_forward_impl!(isize i8 i16 i32 i64 i128);
+euclid_forward_impl!(usize u8 u16 u32 u64 u128);
 
-        #[cfg(not(has_div_euclid))]
-        impl Euclid for $t {
-            #[inline]
-            fn div_euclid(&self, v: &$t) -> Self {
-                let q = self / v;
-                if self % v < 0 {
-                    return if *v > 0 { q - 1 } else { q + 1 }
-                }
-                q
-            }
-
-            #[inline]
-            fn rem_euclid(&self, v: &$t) -> Self {
-                let r = self % v;
-                if r < 0 {
-                    if *v < 0 {
-                        r - v
-                    } else {
-                        r + v
-                    }
-                } else {
-                    r
-                }
-            }
-        }
-    )*}
-}
-
-macro_rules! euclid_uint_impl {
-    ($($t:ty)*) => {$(
-        euclid_forward_impl!($t);
-
-        #[cfg(not(has_div_euclid))]
-        impl Euclid for $t {
-            #[inline]
-            fn div_euclid(&self, v: &$t) -> Self {
-                self / v
-            }
-
-            #[inline]
-            fn rem_euclid(&self, v: &$t) -> Self {
-                self % v
-            }
-        }
-    )*}
-}
-
-euclid_int_impl!(isize i8 i16 i32 i64 i128);
-euclid_uint_impl!(usize u8 u16 u32 u64 u128);
-
-#[cfg(all(has_div_euclid, feature = "std"))]
+#[cfg(feature = "std")]
 euclid_forward_impl!(f32 f64);
 
-#[cfg(not(all(has_div_euclid, feature = "std")))]
+#[cfg(not(feature = "std"))]
 impl Euclid for f32 {
     #[inline]
     fn div_euclid(&self, v: &f32) -> f32 {
@@ -165,7 +113,7 @@ impl Euclid for f32 {
     }
 }
 
-#[cfg(not(all(has_div_euclid, feature = "std")))]
+#[cfg(not(feature = "std"))]
 impl Euclid for f64 {
     #[inline]
     fn div_euclid(&self, v: &f64) -> f64 {
@@ -219,7 +167,6 @@ pub trait CheckedEuclid: Euclid {
 
 macro_rules! checked_euclid_forward_impl {
     ($($t:ty)*) => {$(
-        #[cfg(has_div_euclid)]
         impl CheckedEuclid for $t {
             #[inline]
             fn checked_div_euclid(&self, v: &$t) -> Option<Self> {
@@ -234,62 +181,8 @@ macro_rules! checked_euclid_forward_impl {
     )*}
 }
 
-macro_rules! checked_euclid_int_impl {
-    ($($t:ty)*) => {$(
-        checked_euclid_forward_impl!($t);
-
-        #[cfg(not(has_div_euclid))]
-        impl CheckedEuclid for $t {
-            #[inline]
-            fn checked_div_euclid(&self, v: &$t) -> Option<$t> {
-                if *v == 0 || (*self == Self::min_value() && *v == -1) {
-                    None
-                } else {
-                    Some(Euclid::div_euclid(self, v))
-                }
-            }
-
-            #[inline]
-            fn checked_rem_euclid(&self, v: &$t) -> Option<$t> {
-                if *v == 0 || (*self == Self::min_value() && *v == -1) {
-                    None
-                } else {
-                    Some(Euclid::rem_euclid(self, v))
-                }
-            }
-        }
-    )*}
-}
-
-macro_rules! checked_euclid_uint_impl {
-    ($($t:ty)*) => {$(
-        checked_euclid_forward_impl!($t);
-
-        #[cfg(not(has_div_euclid))]
-        impl CheckedEuclid for $t {
-            #[inline]
-            fn checked_div_euclid(&self, v: &$t) -> Option<$t> {
-                if *v == 0 {
-                    None
-                } else {
-                    Some(Euclid::div_euclid(self, v))
-                }
-            }
-
-            #[inline]
-            fn checked_rem_euclid(&self, v: &$t) -> Option<$t> {
-                if *v == 0 {
-                    None
-                } else {
-                    Some(Euclid::rem_euclid(self, v))
-                }
-            }
-        }
-    )*}
-}
-
-checked_euclid_int_impl!(isize i8 i16 i32 i64 i128);
-checked_euclid_uint_impl!(usize u8 u16 u32 u64 u128);
+checked_euclid_forward_impl!(isize i8 i16 i32 i64 i128);
+checked_euclid_forward_impl!(usize u8 u16 u32 u64 u128);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Earlier versions won't see the incompatible updates at all!
