### PR TITLE
Implement NaN propagating minmax with TotalOrder and FloatCore

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -2245,7 +2245,7 @@ float_const_impl! {
 /// Trait for floating point numbers that provide an implementation
 /// of the `totalOrder` predicate as defined in the IEEE 754 (2008 revision)
 /// floating point standard.
-pub trait TotalOrder {
+pub trait TotalOrder: FloatCore {
     /// Return the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
@@ -2297,6 +2297,32 @@ pub trait TotalOrder {
     /// check_lt(-0.0_f64, 0.0_f64);
     /// ```
     fn total_cmp(&self, other: &Self) -> Ordering;
+
+    /// Get the maximum of two numbers, propagating NaN
+    ///
+    /// For this operation, -0.0 is considered to be less than +0.0 as
+    /// specified in IEEE 754-2019.
+    #[must_use]
+    fn maximum(self, other: Self) -> Self {
+        match (self.is_nan(), other.is_nan()) {
+            (true, _) => self,
+            (_, true) => other,
+            _ => core::cmp::max_by(self, other, Self::total_cmp),
+        }
+    }
+
+    /// Get the minimum of two numbers, propagating NaN
+    ///
+    /// For this operation, -0.0 is considered to be less than +0.0 as
+    /// specified in IEEE 754-2019.
+    #[must_use]
+    fn minimum(self, other: Self) -> Self {
+        match (self.is_nan(), other.is_nan()) {
+            (true, _) => self,
+            (_, true) => other,
+            _ => core::cmp::min_by(self, other, Self::total_cmp),
+        }
+    }
 }
 macro_rules! totalorder_impl {
     ($T:ident, $I:ident, $U:ident, $bits:expr) => {

--- a/src/float.rs
+++ b/src/float.rs
@@ -2245,7 +2245,7 @@ float_const_impl! {
 /// Trait for floating point numbers that provide an implementation
 /// of the `totalOrder` predicate as defined in the IEEE 754 (2008 revision)
 /// floating point standard.
-pub trait TotalOrder: FloatCore {
+pub trait TotalOrder {
     /// Return the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
@@ -2303,7 +2303,10 @@ pub trait TotalOrder: FloatCore {
     /// For this operation, -0.0 is considered to be less than +0.0 as
     /// specified in IEEE 754-2019.
     #[must_use]
-    fn maximum(self, other: Self) -> Self {
+    fn maximum(self, other: Self) -> Self
+    where
+        Self: FloatCore,
+    {
         match (self.is_nan(), other.is_nan()) {
             (true, _) => self,
             (_, true) => other,
@@ -2316,7 +2319,10 @@ pub trait TotalOrder: FloatCore {
     /// For this operation, -0.0 is considered to be less than +0.0 as
     /// specified in IEEE 754-2019.
     #[must_use]
-    fn minimum(self, other: Self) -> Self {
+    fn minimum(self, other: Self) -> Self
+    where
+        Self: FloatCore,
+    {
         match (self.is_nan(), other.is_nan()) {
             (true, _) => self,
             (_, true) => other,


### PR DESCRIPTION
Given the IEEE total-ordering predicate and `.is_nan()`, we can implement NaN propagating minmax, cf. `f32::maximum`.

I'm not sure if using `.is_nan()` with `trait TotalOrder: FloatCore` is the best idea, but I can't think of a better one for now.