### PR TITLE
Murisi/generic unextended checked traits

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, Mul};
 /// a + 0 = a       ∀ a ∈ Self
 /// 0 + a = a       ∀ a ∈ Self
 /// ```
-pub trait Zero: Sized + Add<Self, Output = Self> {
+pub trait Zero: Sized {
     /// Returns the additive identity element of `Self`, `0`.
     /// # Purity
     ///
@@ -103,7 +103,7 @@ where
 /// a * 1 = a       ∀ a ∈ Self
 /// 1 * a = a       ∀ a ∈ Self
 /// ```
-pub trait One: Sized + Mul<Self, Output = Self> {
+pub trait One: Sized {
     /// Returns the multiplicative identity element of `Self`, `1`.
     ///
     /// # Purity

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -9,7 +9,7 @@ pub trait CheckedAdd<Rhs = Self>: Sized {
 
 macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        impl $trait_name<$t> for $t {
             type Output = $t;
             #[inline]
             fn $method(self, v: $t) -> Option<$t> {
@@ -17,7 +17,23 @@ macro_rules! checked_impl {
             }
         }
 
-        impl $trait_name for &$t {
+        impl $trait_name<&$t> for $t {
+            type Output = $t;
+            #[inline]
+            fn $method(self, v: &$t) -> Option<$t> {
+                <$t>::$method(self, *v)
+            }
+        }
+
+        impl $trait_name<$t> for &$t {
+            type Output = $t;
+            #[inline]
+            fn $method(self, v: $t) -> Option<$t> {
+                <$t>::$method(*self, v)
+            }
+        }
+
+        impl $trait_name<&$t> for &$t {
             type Output = $t;
             #[inline]
             fn $method(self, v: &$t) -> Option<$t> {

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -1,6 +1,4 @@
-use core::ops::{Div, Rem};
-
-pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
+pub trait Euclid: Sized {
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
     ///
     /// This computes the integer `n` such that

--- a/src/ops/overflowing.rs
+++ b/src/ops/overflowing.rs
@@ -1,12 +1,36 @@
-use core::ops::{Add, Mul, Sub};
 use core::{i128, i16, i32, i64, i8, isize};
 use core::{u128, u16, u32, u64, u8, usize};
 
 macro_rules! overflowing_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
-        impl $trait_name for $t {
+        impl $trait_name<$t> for $t {
+            type Output = $t;
             #[inline]
-            fn $method(&self, v: &Self) -> (Self, bool) {
+            fn $method(self, v: $t) -> ($t, bool) {
+                <$t>::$method(self, v)
+            }
+        }
+
+        impl $trait_name<&$t> for $t {
+            type Output = $t;
+            #[inline]
+            fn $method(self, v: &$t) -> ($t, bool) {
+                <$t>::$method(self, *v)
+            }
+        }
+
+        impl $trait_name<$t> for &$t {
+            type Output = $t;
+            #[inline]
+            fn $method(self, v: $t) -> ($t, bool) {
+                <$t>::$method(*self, v)
+            }
+        }
+
+        impl $trait_name<&$t> for &$t {
+            type Output = $t;
+            #[inline]
+            fn $method(self, v: &$t) -> ($t, bool) {
                 <$t>::$method(*self, *v)
             }
         }
@@ -14,10 +38,11 @@ macro_rules! overflowing_impl {
 }
 
 /// Performs addition with a flag for overflow.
-pub trait OverflowingAdd: Sized + Add<Self, Output = Self> {
+pub trait OverflowingAdd<Rhs = Self>: Sized {
+    type Output;
     /// Returns a tuple of the sum along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_add(&self, v: &Self) -> (Self, bool);
+    fn overflowing_add(self, v: Rhs) -> (Self::Output, bool);
 }
 
 overflowing_impl!(OverflowingAdd, overflowing_add, u8);
@@ -35,10 +60,11 @@ overflowing_impl!(OverflowingAdd, overflowing_add, isize);
 overflowing_impl!(OverflowingAdd, overflowing_add, i128);
 
 /// Performs substraction with a flag for overflow.
-pub trait OverflowingSub: Sized + Sub<Self, Output = Self> {
+pub trait OverflowingSub<Rhs = Self>: Sized {
+    type Output;
     /// Returns a tuple of the difference along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_sub(&self, v: &Self) -> (Self, bool);
+    fn overflowing_sub(self, v: Rhs) -> (Self::Output, bool);
 }
 
 overflowing_impl!(OverflowingSub, overflowing_sub, u8);
@@ -56,10 +82,11 @@ overflowing_impl!(OverflowingSub, overflowing_sub, isize);
 overflowing_impl!(OverflowingSub, overflowing_sub, i128);
 
 /// Performs multiplication with a flag for overflow.
-pub trait OverflowingMul: Sized + Mul<Self, Output = Self> {
+pub trait OverflowingMul<Rhs = Self>: Sized {
+    type Output;
     /// Returns a tuple of the product along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_mul(&self, v: &Self) -> (Self, bool);
+    fn overflowing_mul(self, v: Rhs) -> (Self::Output, bool);
 }
 
 overflowing_impl!(OverflowingMul, overflowing_mul, u8);

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -1,5 +1,3 @@
-use core::ops::{Add, Mul, Sub};
-
 /// Saturating math operations. Deprecated, use `SaturatingAdd`, `SaturatingSub` and
 /// `SaturatingMul` instead.
 pub trait Saturating {
@@ -43,7 +41,7 @@ macro_rules! saturating_impl {
 }
 
 /// Performs addition that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingAdd: Sized + Add<Self, Output = Self> {
+pub trait SaturatingAdd: Sized {
     /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_add(&self, v: &Self) -> Self;
@@ -64,7 +62,7 @@ saturating_impl!(SaturatingAdd, saturating_add, isize);
 saturating_impl!(SaturatingAdd, saturating_add, i128);
 
 /// Performs subtraction that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingSub: Sized + Sub<Self, Output = Self> {
+pub trait SaturatingSub: Sized {
     /// Saturating subtraction. Computes `self - other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_sub(&self, v: &Self) -> Self;
@@ -85,7 +83,7 @@ saturating_impl!(SaturatingSub, saturating_sub, isize);
 saturating_impl!(SaturatingSub, saturating_sub, i128);
 
 /// Performs multiplication that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingMul: Sized + Mul<Self, Output = Self> {
+pub trait SaturatingMul: Sized {
     /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_mul(&self, v: &Self) -> Self;

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -21,7 +21,7 @@ macro_rules! wrapping_impl {
 }
 
 /// Performs addition that wraps around on overflow.
-pub trait WrappingAdd: Sized + Add<Self, Output = Self> {
+pub trait WrappingAdd: Sized {
     /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of
     /// the type.
     fn wrapping_add(&self, v: &Self) -> Self;
@@ -42,7 +42,7 @@ wrapping_impl!(WrappingAdd, wrapping_add, isize);
 wrapping_impl!(WrappingAdd, wrapping_add, i128);
 
 /// Performs subtraction that wraps around on overflow.
-pub trait WrappingSub: Sized + Sub<Self, Output = Self> {
+pub trait WrappingSub: Sized {
     /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary
     /// of the type.
     fn wrapping_sub(&self, v: &Self) -> Self;
@@ -63,7 +63,7 @@ wrapping_impl!(WrappingSub, wrapping_sub, isize);
 wrapping_impl!(WrappingSub, wrapping_sub, i128);
 
 /// Performs multiplication that wraps around on overflow.
-pub trait WrappingMul: Sized + Mul<Self, Output = Self> {
+pub trait WrappingMul: Sized {
     /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary
     /// of the type.
     fn wrapping_mul(&self, v: &Self) -> Self;
@@ -141,7 +141,7 @@ macro_rules! wrapping_shift_impl {
 }
 
 /// Performs a left shift that does not panic.
-pub trait WrappingShl: Sized + Shl<usize, Output = Self> {
+pub trait WrappingShl: Sized {
     /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
@@ -174,7 +174,7 @@ wrapping_shift_impl!(WrappingShl, wrapping_shl, isize);
 wrapping_shift_impl!(WrappingShl, wrapping_shl, i128);
 
 /// Performs a right shift that does not panic.
-pub trait WrappingShr: Sized + Shr<usize, Output = Self> {
+pub trait WrappingShr: Sized {
     /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -217,7 +217,10 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
 /// assert_eq!(checked_pow(0u32, 0), Some(1)); // Be aware if this case affect you
 /// ```
 #[inline]
-pub fn checked_pow<T: Clone + One + CheckedMul<Output = T>>(mut base: T, mut exp: usize) -> Option<T> {
+pub fn checked_pow<T: Clone + One + CheckedMul<Output = T>>(
+    mut base: T,
+    mut exp: usize,
+) -> Option<T> {
     if exp == 0 {
         return Some(T::one());
     }
@@ -240,4 +243,3 @@ pub fn checked_pow<T: Clone + One + CheckedMul<Output = T>>(mut base: T, mut exp
     }
     Some(acc)
 }
-

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -217,13 +217,13 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
 /// assert_eq!(checked_pow(0u32, 0), Some(1)); // Be aware if this case affect you
 /// ```
 #[inline]
-pub fn checked_pow<T: Clone + One + CheckedMul>(mut base: T, mut exp: usize) -> Option<T> {
+pub fn checked_pow<T: Clone + One + CheckedMul<Output = T>>(mut base: T, mut exp: usize) -> Option<T> {
     if exp == 0 {
         return Some(T::one());
     }
 
     while exp & 1 == 0 {
-        base = base.checked_mul(&base)?;
+        base = base.clone().checked_mul(base)?;
         exp >>= 1;
     }
     if exp == 1 {
@@ -233,10 +233,11 @@ pub fn checked_pow<T: Clone + One + CheckedMul>(mut base: T, mut exp: usize) -> 
     let mut acc = base.clone();
     while exp > 1 {
         exp >>= 1;
-        base = base.checked_mul(&base)?;
+        base = base.clone().checked_mul(base)?;
         if exp & 1 == 1 {
-            acc = acc.checked_mul(&base)?;
+            acc = acc.checked_mul(base.clone())?;
         }
     }
     Some(acc)
 }
+


### PR DESCRIPTION
Adjusted `num-traits` so that the checked traits are now generic and so that they do not depend on their unchecked equivalents. Given the new use of generic, the traits are now define for both reference and value types.