### PR TITLE
Clarify example for trait method `float::Float::integer_decode`

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -1872,10 +1872,10 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let (mantissa, exponent, sign) = Float::integer_decode(num);
     /// let sign_f = sign as f32;
     /// let mantissa_f = mantissa as f32;
-    /// let exponent_f = num.powf(exponent as f32);
+    /// let exponent_f = exponent as f32;
     ///
     /// // 1 * 8388608 * 2^(-22) == 2
-    /// let abs_difference = (sign_f * mantissa_f * exponent_f - num).abs();
+    /// let abs_difference = (sign_f * mantissa_f * 2_f32.powf(exponent_f) - num).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```

--- a/src/float.rs
+++ b/src/float.rs
@@ -1875,7 +1875,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// let exponent_f = exponent as f32;
     ///
     /// // 1 * 11010048 * 2^(-18) == 42
-    /// let abs_difference = (sign_f * mantissa_f * 2_f32.powf(exponent_f) - num).abs();
+    /// let abs_difference = (sign_f * mantissa_f * exponent_f.exp2() - num).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```

--- a/src/float.rs
+++ b/src/float.rs
@@ -1866,15 +1866,15 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// ```
     /// use num_traits::Float;
     ///
-    /// let num = 2.0f32;
+    /// let num = 42_f32;
     ///
-    /// // (8388608, -22, 1)
+    /// // (11010048, -18, 1)
     /// let (mantissa, exponent, sign) = Float::integer_decode(num);
     /// let sign_f = sign as f32;
     /// let mantissa_f = mantissa as f32;
     /// let exponent_f = exponent as f32;
     ///
-    /// // 1 * 8388608 * 2^(-22) == 2
+    /// // 1 * 11010048 * 2^(-18) == 42
     /// let abs_difference = (sign_f * mantissa_f * 2_f32.powf(exponent_f) - num).abs();
     ///
     /// assert!(abs_difference < 1e-10);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/126610

### Problem

The example for trait method [float::Float::integer_decode](https://docs.rs/num-traits/0.2.19/num_traits/float/trait.Float.html#tymethod.integer_decode) fails if `num` is changed to most any value other than 2.

```rs
use num_traits::Float;

let num = 2.0f32;

// (8388608, -22, 1)
let (mantissa, exponent, sign) = Float::integer_decode(num);
let sign_f = sign as f32;
let mantissa_f = mantissa as f32;
let exponent_f = num.powf(exponent as f32);

// 1 * 8388608 * 2^(-22) == 2
let abs_difference = (sign_f * mantissa_f * exponent_f - num).abs();

assert!(abs_difference < 1e-10);
```

### Changes

* The equation used to recover the original number, `num`, from the outputs of `Float::integer_decode(num)` is given in the doc comment as `sign * mantissa * 2 ^ exponent`. However, in the example, `num` was being used as the exponent's base, as in the equation `sign * mantissa * num ^ exponent`. This PR fixes that mistake.

* It follows logically that when `num` is 2, the example behaves correctly even with the bug. To reduce confusion, this PR changes the value of `num` in the example to be 42.

* For readability, this PR also moves the invocation of `.powf(exponent as f32)`, so it is directly underneath the comment `// 1 * 11010048 * 2^(-18) == 42`.

### Updated example

```rs
use num_traits::Float;

let num = 42_f32;

// (11010048, -18, 1)
let (mantissa, exponent, sign) = Float::integer_decode(num);
let sign_f = sign as f32;
let mantissa_f = mantissa as f32;
let exponent_f = exponent as f32;

// 1 * 11010048 * 2^(-18) == 42
let abs_difference = (sign_f * mantissa_f * exponent_f.exp2() - num).abs();

assert!(abs_difference < 1e-10);
```
