### PR TITLE
Add unit tests for trait method `float::Float::integer_decode`

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -2470,8 +2470,6 @@ mod tests {
             test_integer_decode(sign_f * f32::MAX, (0xffffff, 104, sign));
             test_integer_decode(sign_f * f32::INFINITY, (0x800000, 105, sign));
         }
-        // FIXME: Unclear if we should be able to recover NaN inputs
-        // test_integer_decode(f32::NAN, (0xc00000, 105, 1));
     }
 
     #[test]
@@ -2494,8 +2492,6 @@ mod tests {
             test_integer_decode(sign_f * f64::MAX, (0x1fffffffffffff, 971, sign));
             test_integer_decode(sign_f * f64::INFINITY, (0x10000000000000, 972, sign));
         }
-        // FIXME: Unclear if we should be able to recover NaN inputs
-        // test_integer_decode(f64::NAN, (0x18000000000000, 972, 1));
     }
 
     #[test]

--- a/src/float.rs
+++ b/src/float.rs
@@ -2456,6 +2456,7 @@ mod tests {
         for sign in [1, -1] {
             let sign_f = sign as f32;
             test_integer_decode(sign_f * 0.0__f32, (0x000000, -150, sign));
+            test_integer_decode(sign_f * 1.0e-40_f32, (0x022d84, -150, sign)); // subnormal (between 0 and MIN_POSITIVE)
             test_integer_decode(sign_f * f32::MIN_POSITIVE, (0x800000, -149, sign));
             test_integer_decode(sign_f * 0.25_f32, (0x800000, -25, sign));
             test_integer_decode(sign_f * 0.5__f32, (0x800000, -24, sign));
@@ -2478,6 +2479,7 @@ mod tests {
         for sign in [1, -1] {
             let sign_f = sign as f64;
             test_integer_decode(sign_f * 0.0__f64, (0x00000000000000, -1075, sign));
+            test_integer_decode(sign_f * 1.0e-308_f64, (0x0e61acf033d1a4, -1075, sign)); // subnormal (between 0 and MIN_POSITIVE)
             test_integer_decode(sign_f * f64::MIN_POSITIVE, (0x10000000000000, -1074, sign));
             test_integer_decode(sign_f * 0.25_f64, (0x10000000000000, -54, sign));
             test_integer_decode(sign_f * 0.5__f64, (0x10000000000000, -53, sign));

--- a/src/float.rs
+++ b/src/float.rs
@@ -2055,8 +2055,10 @@ fn integer_decode_f32(f: f32) -> (u64, i16, i8) {
     let sign: i8 = if bits >> 31 == 0 { 1 } else { -1 };
     let mut exponent: i16 = ((bits >> 23) & 0xff) as i16;
     let mantissa = if exponent == 0 {
+        // Zeros and subnormals
         (bits & 0x7fffff) << 1
     } else {
+        // Normals, infinities, and NaN
         (bits & 0x7fffff) | 0x800000
     };
     // Exponent bias + mantissa shift
@@ -2069,8 +2071,10 @@ fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
     let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
     let mantissa = if exponent == 0 {
+        // Zeros and subnormals
         (bits & 0xfffffffffffff) << 1
     } else {
+        // Normals, infinities, and NaN
         (bits & 0xfffffffffffff) | 0x10000000000000
     };
     // Exponent bias + mantissa shift

--- a/src/float.rs
+++ b/src/float.rs
@@ -2466,6 +2466,8 @@ mod tests {
             test_integer_decode(sign_f * f32::MAX, (0xffffff, 104, sign));
             test_integer_decode(sign_f * f32::INFINITY, (0x800000, 105, sign));
         }
+        // FIXME: Unclear if we should be able to recover NaN inputs
+        // test_integer_decode(f32::NAN, (0xc00000, 105, 1));
     }
 
     #[test]
@@ -2488,6 +2490,8 @@ mod tests {
             test_integer_decode(sign_f * f64::MAX, (0x1fffffffffffff, 971, sign));
             test_integer_decode(sign_f * f64::INFINITY, (0x10000000000000, 972, sign));
         }
+        // FIXME: Unclear if we should be able to recover NaN inputs
+        // test_integer_decode(f64::NAN, (0x18000000000000, 972, 1));
     }
 
     #[test]

--- a/src/float.rs
+++ b/src/float.rs
@@ -2411,7 +2411,7 @@ mod tests {
             expected == found,
             "unexpected output of `Float::integer_decode({0:e})`
 \texpected: ({1:#x} {2} {3})
-\t   found: {4:#x} {5} {6}",
+\t   found: ({4:#x} {5} {6})",
             given,
             expected.0,
             expected.1,

--- a/src/float.rs
+++ b/src/float.rs
@@ -775,7 +775,9 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     fn to_radians(self) -> Self;
 
     /// Returns the mantissa, base 2 exponent, and sign as integers, respectively.
+    ///
     /// The original number can be recovered by `sign * mantissa * 2 ^ exponent`.
+    /// This formula only works for zero, normal, and infinite numbers (per `classify()`)
     ///
     /// # Examples
     ///
@@ -1861,7 +1863,9 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     fn atanh(self) -> Self;
 
     /// Returns the mantissa, base 2 exponent, and sign as integers, respectively.
+    ///
     /// The original number can be recovered by `sign * mantissa * 2 ^ exponent`.
+    /// This formula only works for zero, normal, and infinite numbers (per `classify()`)
     ///
     /// ```
     /// use num_traits::Float;


### PR DESCRIPTION
### Motivation

While working on #326, I saw an opportunity to add unit test coverage for the trait method `float::Float::integer_decode`. I hope others find this helpful when troubleshooting this method.

### Changes

* Add unit test coverage for the trait method `Float::integer_decode` with 32-bit and 64-bit inputs.
* Update doc comments to clarify how to recover inputs to `Float::integer_decode`.