### PR TITLE
Make `float::Float::integer_decode` DRY

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -4,7 +4,6 @@ use core::ops::{Add, Div, Neg};
 
 use core::f32;
 use core::f64;
-use std::println;
 
 use crate::{Num, NumCast, ToPrimitive};
 
@@ -2063,17 +2062,10 @@ macro_rules! integer_decode {
         $exponent_bias:expr
     ) => {
         fn $func_name(f: $T) -> (u64, i16, i8) {
-            println!("            sign_bit_index: {}", $sign_bit_index);
-            println!(" fraction_bits_start_index: {}", $fraction_bits_start_index);
-            println!("            postshift_mask: {:064b}", $postshift_mask);
-            println!("        fraction_bits_mask: {:064b}", $fraction_bits_mask);
-            println!("exponent_trailing_bit_mask: {:064b}", $exponent_trailing_bit_mask);
-            println!("             exponent_bias: {}", $exponent_bias);
-
             let bits = f.to_bits();
-            println!("                      bits: {:064b}", bits);
 
             let sign: i8 = if bits >> $sign_bit_index == 0 { 1 } else { -1 };
+
             let mantissa = if f == 0 as $T {
                 // Zeros and subnormals
                 (bits & $fraction_bits_mask) << 1

--- a/src/float.rs
+++ b/src/float.rs
@@ -2470,8 +2470,6 @@ mod tests {
             test_integer_decode(sign_f * f32::MAX, (0xffffff, 104, sign));
             test_integer_decode(sign_f * f32::INFINITY, (0x800000, 105, sign));
         }
-        // FIXME: Unclear if we should be able to recover NaN inputs
-        // test_integer_decode(f32::NAN, (0xc00000, 105, 1));
     }
 
     #[test]
@@ -2494,8 +2492,6 @@ mod tests {
             test_integer_decode(sign_f * f64::MAX, (0x1fffffffffffff, 971, sign));
             test_integer_decode(sign_f * f64::INFINITY, (0x10000000000000, 972, sign));
         }
-        // FIXME: Unclear if we should be able to recover NaN inputs
-        // test_integer_decode(f64::NAN, (0x18000000000000, 972, 1));
     }
 
     #[test]

--- a/src/float.rs
+++ b/src/float.rs
@@ -2456,6 +2456,7 @@ mod tests {
         for sign in [1, -1] {
             let sign_f = sign as f32;
             test_integer_decode(sign_f * 0.0__f32, (0x000000, -150, sign));
+            test_integer_decode(sign_f * 1.0e-40_f32, (0x022d84, -150, sign)); // subnormal (between 0 and MIN_POSITIVE)
             test_integer_decode(sign_f * f32::MIN_POSITIVE, (0x800000, -149, sign));
             test_integer_decode(sign_f * 0.25_f32, (0x800000, -25, sign));
             test_integer_decode(sign_f * 0.5__f32, (0x800000, -24, sign));
@@ -2478,6 +2479,7 @@ mod tests {
         for sign in [1, -1] {
             let sign_f = sign as f64;
             test_integer_decode(sign_f * 0.0__f64, (0x00000000000000, -1075, sign));
+            test_integer_decode(sign_f * 1.0e-308_f64, (0x0e61acf033d1a4, -1075, sign)); // subnormal (between 0 and MIN_POSITIVE)
             test_integer_decode(sign_f * f64::MIN_POSITIVE, (0x10000000000000, -1074, sign));
             test_integer_decode(sign_f * 0.25_f64, (0x10000000000000, -54, sign));
             test_integer_decode(sign_f * 0.5__f64, (0x10000000000000, -53, sign));

--- a/src/float.rs
+++ b/src/float.rs
@@ -2055,8 +2055,10 @@ fn integer_decode_f32(f: f32) -> (u64, i16, i8) {
     let sign: i8 = if bits >> 31 == 0 { 1 } else { -1 };
     let mut exponent: i16 = ((bits >> 23) & 0xff) as i16;
     let mantissa = if exponent == 0 {
+        // Zeros and subnormals
         (bits & 0x7fffff) << 1
     } else {
+        // Normals, infinities, and NaN
         (bits & 0x7fffff) | 0x800000
     };
     // Exponent bias + mantissa shift
@@ -2069,8 +2071,10 @@ fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
     let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
     let mantissa = if exponent == 0 {
+        // Zeros and subnormals
         (bits & 0xfffffffffffff) << 1
     } else {
+        // Normals, infinities, and NaN
         (bits & 0xfffffffffffff) | 0x10000000000000
     };
     // Exponent bias + mantissa shift

--- a/src/float.rs
+++ b/src/float.rs
@@ -2466,6 +2466,8 @@ mod tests {
             test_integer_decode(sign_f * f32::MAX, (0xffffff, 104, sign));
             test_integer_decode(sign_f * f32::INFINITY, (0x800000, 105, sign));
         }
+        // FIXME: Unclear if we should be able to recover NaN inputs
+        // test_integer_decode(f32::NAN, (0xc00000, 105, 1));
     }
 
     #[test]
@@ -2488,6 +2490,8 @@ mod tests {
             test_integer_decode(sign_f * f64::MAX, (0x1fffffffffffff, 971, sign));
             test_integer_decode(sign_f * f64::INFINITY, (0x10000000000000, 972, sign));
         }
+        // FIXME: Unclear if we should be able to recover NaN inputs
+        // test_integer_decode(f64::NAN, (0x18000000000000, 972, 1));
     }
 
     #[test]

--- a/src/float.rs
+++ b/src/float.rs
@@ -2411,7 +2411,7 @@ mod tests {
             expected == found,
             "unexpected output of `Float::integer_decode({0:e})`
 \texpected: ({1:#x} {2} {3})
-\t   found: {4:#x} {5} {6}",
+\t   found: ({4:#x} {5} {6})",
             given,
             expected.0,
             expected.1,

--- a/src/float.rs
+++ b/src/float.rs
@@ -2066,7 +2066,9 @@ macro_rules! integer_decode {
 
             let sign: i8 = if bits >> $size - 1 == 0 { 1 } else { -1 };
 
-            let mantissa = if f == 0 as $F {
+            let mut exponent: i16 = (bits >> $fraction_size & $postshift_exponent_bits_mask) as i16;
+
+            let mantissa = if exponent == 0 {
                 // Zeros and subnormals
                 (bits & $fraction_bits_mask) << 1
             } else {
@@ -2074,7 +2076,6 @@ macro_rules! integer_decode {
                 (bits & $fraction_bits_mask) | $exponent_least_signifigant_bit_mask
             };
 
-            let mut exponent: i16 = (bits >> $fraction_size & $postshift_exponent_bits_mask) as i16;
             exponent -= $exponent_bias + $fraction_size;
 
             (mantissa as u64, exponent, sign)

--- a/src/float.rs
+++ b/src/float.rs
@@ -775,7 +775,9 @@ pub trait FloatCore: Num + NumCast + Neg<Output = Self> + PartialOrd + Copy {
     fn to_radians(self) -> Self;
 
     /// Returns the mantissa, base 2 exponent, and sign as integers, respectively.
+    ///
     /// The original number can be recovered by `sign * mantissa * 2 ^ exponent`.
+    /// This formula only works for zero, normal, and infinite numbers (per `classify()`)
     ///
     /// # Examples
     ///
@@ -1861,7 +1863,9 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     fn atanh(self) -> Self;
 
     /// Returns the mantissa, base 2 exponent, and sign as integers, respectively.
+    ///
     /// The original number can be recovered by `sign * mantissa * 2 ^ exponent`.
+    /// This formula only works for zero, normal, and infinite numbers (per `classify()`)
     ///
     /// ```
     /// use num_traits::Float;


### PR DESCRIPTION
Blocked by #327

### Motivation

The trait method `float::Float::integer_decode` invokes one of the functions `integer_decode_f32` or `integer_decode_f64` depending on the implementation. These functions share a lot of code, so I would like to refactor them to use the same underlying source.

### Considerations

* Since this is lower-level bit-shifting code, I should take care not to damage performance. Critiques about performance optimization are extremely welcome.
* To avoid causing breaking changes, I proposed wrote unit tests to this method in #327.

### Status

This is a work in progress, as indicated by the fact that it is a Draft PR. Comments and suggestions are welcome, but not expected.
