### PR TITLE
Two::two() and OneHalf::one_half()

### DIFF
--- a/src/identities.rs
+++ b/src/identities.rs
@@ -133,6 +133,44 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     }
 }
 
+/// Defines twice the multiplicative identity element for `Self`.
+///
+/// # Laws
+///
+/// ```text
+/// a * 2 = a + a      ∀ a ∈ Self
+/// 2 * a = a + a      ∀ a ∈ Self
+/// ```
+pub trait Two: One {
+    /// Returns twice the multiplicative identity element of `Self`, `2`.
+    ///
+    /// # Purity
+    ///
+    /// This function should return the same result at all times regardless of
+    /// external mutable state, for example values stored in TLS or in
+    /// `static mut`s.
+    // This cannot be an associated constant, because of bignums.
+    fn two() -> Self;
+
+    /// Sets `self` to twice the multiplicative identity element of `Self`, `2`.
+    fn set_two(&mut self) {
+        *self = Two::two();
+    }
+
+    /// Returns `true` if `self` is equal to twice the multiplicative identity.
+    ///
+    /// For performance reasons, it's best to implement this manually.
+    /// After a semver bump, this method will be required, and the
+    /// `where Self: PartialEq` bound will be removed.
+    #[inline]
+    fn is_two(&self) -> bool
+    where
+        Self: PartialEq,
+    {
+        *self == Self::two()
+    }
+}
+
 /// Defines an associated constant representing the multiplicative identity
 /// element for `Self`.
 pub trait ConstOne: One {
@@ -140,52 +178,74 @@ pub trait ConstOne: One {
     const ONE: Self;
 }
 
-macro_rules! one_impl {
-    ($t:ty, $v:expr) => {
+/// Defines an associated constant representing twice the multiplicative identity
+/// element for `Self`.
+pub trait ConstTwo: Two {
+    /// Twice the multiplicative identity element of `Self`, `2`.
+    const TWO: Self;
+}
+
+macro_rules! one_two_impl {
+    ($t:ty, $one:expr, $two:expr) => {
         impl One for $t {
             #[inline]
             fn one() -> $t {
-                $v
+                $one
             }
             #[inline]
             fn is_one(&self) -> bool {
-                *self == $v
+                *self == $one
             }
         }
 
         impl ConstOne for $t {
-            const ONE: Self = $v;
+            const ONE: Self = $one;
+        }
+
+        impl Two for $t {
+            #[inline]
+            fn two() -> $t {
+                $two
+            }
+            #[inline]
+            fn is_two(&self) -> bool {
+                *self == $two
+            }
+        }
+
+        impl ConstTwo for $t {
+            const TWO: Self = $two;
         }
     };
 }
 
-one_impl!(usize, 1);
-one_impl!(u8, 1);
-one_impl!(u16, 1);
-one_impl!(u32, 1);
-one_impl!(u64, 1);
-one_impl!(u128, 1);
+one_two_impl!(usize, 1, 2);
+one_two_impl!(u8, 1, 2);
+one_two_impl!(u16, 1, 2);
+one_two_impl!(u32, 1, 2);
+one_two_impl!(u64, 1, 2);
+one_two_impl!(u128, 1, 2);
 
-one_impl!(isize, 1);
-one_impl!(i8, 1);
-one_impl!(i16, 1);
-one_impl!(i32, 1);
-one_impl!(i64, 1);
-one_impl!(i128, 1);
+one_two_impl!(isize, 1, 2);
+one_two_impl!(i8, 1, 2);
+one_two_impl!(i16, 1, 2);
+one_two_impl!(i32, 1, 2);
+one_two_impl!(i64, 1, 2);
+one_two_impl!(i128, 1, 2);
 
-one_impl!(f32, 1.0);
-one_impl!(f64, 1.0);
+one_two_impl!(f32, 1.0, 2.0);
+one_two_impl!(f64, 1.0, 2.0);
 
 impl<T: One> One for Wrapping<T>
 where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {
-    fn set_one(&mut self) {
-        self.0.set_one();
-    }
-
     fn one() -> Self {
         Wrapping(T::one())
+    }
+
+    fn set_one(&mut self) {
+        self.0.set_one();
     }
 }
 
@@ -194,6 +254,26 @@ where
     Wrapping<T>: Mul<Output = Wrapping<T>>,
 {
     const ONE: Self = Wrapping(T::ONE);
+}
+
+impl<T: Two> Two for Wrapping<T>
+where
+    Wrapping<T>: Mul<Output = Wrapping<T>>,
+{
+    fn two() -> Self {
+        Wrapping(T::two())
+    }
+
+    fn set_two(&mut self) {
+        self.0.set_two();
+    }
+}
+
+impl<T: ConstTwo> ConstTwo for Wrapping<T>
+where
+    Wrapping<T>: Mul<Output = Wrapping<T>>,
+{
+    const TWO: Self = Wrapping(T::TWO);
 }
 
 // Some helper functions provided for backwards compatibility.
@@ -210,6 +290,12 @@ pub fn one<T: One>() -> T {
     One::one()
 }
 
+/// Returns twice the multiplicative identity, `2`.
+#[inline(always)]
+pub fn two<T: Two>() -> T {
+    Two::two()
+}
+
 #[test]
 fn wrapping_identities() {
     macro_rules! test_wrapping_identities {
@@ -217,6 +303,7 @@ fn wrapping_identities() {
             $(
                 assert_eq!(zero::<$t>(), zero::<Wrapping<$t>>().0);
                 assert_eq!(one::<$t>(), one::<Wrapping<$t>>().0);
+                assert_eq!(two::<$t>(), two::<Wrapping<$t>>().0);
                 assert_eq!((0 as $t).is_zero(), Wrapping(0 as $t).is_zero());
                 assert_eq!((1 as $t).is_zero(), Wrapping(1 as $t).is_zero());
             )+
@@ -231,8 +318,15 @@ fn wrapping_is_zero() {
     fn require_zero<T: Zero>(_: &T) {}
     require_zero(&Wrapping(42));
 }
+
 #[test]
 fn wrapping_is_one() {
     fn require_one<T: One>(_: &T) {}
     require_one(&Wrapping(42));
+}
+
+#[test]
+fn wrapping_is_two() {
+    fn require_two<T: Two>(_: &T) {}
+    require_two(&Wrapping(42));
 }


### PR DESCRIPTION
This adds the traits `Two`, `ConstTwo`, as well as `OneHalf` and `ConstOneHalf` respectively. It's like `One`, just twice as good ... or half.

---

This may seem overkill at first glance, but I have found myself re-implementing

```rust
let two = T::one() + T::one();
let one_half = T::one() / two;
```

repeatedly when implementing digital filters that are either floating- or fixed-point. The need arises for example when differentiating nonlinear equations in order to provide their [Laplacians](https://en.wikipedia.org/wiki/Laplace_operator) for linear approximation. While a square can be implemented trivially (`a * a`), the differentiation of it (`2 * a`) causes the issue. 

---

I provided `OneHalf`/`ConstOneHalf` since they are dual to `Two`/`ConstTwo`. They could be derived, but that would require an additional `Div<T>` trait bound (whereas `Mul<T>` is already required by `One`). Given that multiplication is generally faster than division, having it at hand is useful.