### PR TITLE
some set of generic based non zero support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-num/num-traits"
 name = "num-traits"
-version = "0.2.19"
+version = "1.2.19"
 readme = "README.md"
 build = "build.rs"
 exclude = ["/ci/*", "/.github/*"]
@@ -21,14 +21,18 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies]
 libm = { version = "0.2.0", optional = true }
+rustversion.version = "1"
 
 [features]
-default = ["std"]
+default = ["std", "unstable_1"]
 libm = ["dep:libm"]
 std = []
 
 # vestigial features, now always in effect
 i128 = []
 
+unstable_1 = []
+
 [build-dependencies]
 autocfg = "1"
+semver = "1"

--- a/build.rs
+++ b/build.rs
@@ -4,4 +4,11 @@ fn main() {
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
 
     autocfg::rerun_path("build.rs");
+
+    let version: semver::Version = 
+    std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION must be set").parse().expect("Cargo.toml of this crate to be correct version format");
+    
+    if version.major >= 1 {
+        println!("cargo:rustc-cfg=unstable_1")
+    }
 }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,4 +1,4 @@
-use core::num::Wrapping;
+use core::num::{NonZero, Wrapping};
 use core::{f32, f64};
 use core::{i128, i16, i32, i64, i8, isize};
 use core::{u128, u16, u32, u64, u8, usize};
@@ -26,6 +26,7 @@ impl<T: Bounded> LowerBounded for T {
 }
 
 /// Numbers which have upper bounds
+//ASDF
 pub trait UpperBounded {
     /// Returns the largest finite number this type can represent
     fn max_value() -> Self;
@@ -61,12 +62,24 @@ bounded_impl!(u32, u32::MIN, u32::MAX);
 bounded_impl!(u64, u64::MIN, u64::MAX);
 bounded_impl!(u128, u128::MIN, u128::MAX);
 
+bounded_impl!(NonZero<u8>, NonZero::<u8>::MIN, NonZero::<u8>::MAX);
+bounded_impl!(NonZero<u16>, NonZero::<u16>::MIN, NonZero::<u16>::MAX);
+bounded_impl!(NonZero<u32>, NonZero::<u32>::MIN, NonZero::<u32>::MAX);
+bounded_impl!(NonZero<u64>, NonZero::<u64>::MIN, NonZero::<u64>::MAX);
+bounded_impl!(NonZero<u128>, NonZero::<u128>::MIN, NonZero::<u128>::MAX);
+
 bounded_impl!(isize, isize::MIN, isize::MAX);
 bounded_impl!(i8, i8::MIN, i8::MAX);
 bounded_impl!(i16, i16::MIN, i16::MAX);
 bounded_impl!(i32, i32::MIN, i32::MAX);
 bounded_impl!(i64, i64::MIN, i64::MAX);
 bounded_impl!(i128, i128::MIN, i128::MAX);
+
+bounded_impl!(NonZero<i8>, NonZero::<i8>::MIN, NonZero::<i8>::MAX);
+bounded_impl!(NonZero<i16>, NonZero::<i16>::MIN, NonZero::<i16>::MAX);
+bounded_impl!(NonZero<i32>, NonZero::<i32>::MIN, NonZero::<i32>::MAX);
+bounded_impl!(NonZero<i64>, NonZero::<i64>::MIN, NonZero::<i64>::MAX);
+bounded_impl!(NonZero<i128>, NonZero::<i128>::MIN, NonZero::<i128>::MAX);
 
 impl<T: Bounded> Bounded for Wrapping<T> {
     fn min_value() -> Self {

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,4 +1,4 @@
-use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
+use core::ops::{BitAnd, BitOr, BitXor, Mul, Not, Shl, Shr};
 
 use crate::bounds::Bounded;
 use crate::ops::checked::*;
@@ -49,6 +49,7 @@ pub trait PrimInt:
     + CheckedAdd<Output = Self>
     + CheckedSub<Output = Self>
     + CheckedMul<Output = Self>
+    + Mul<Output = Self>
     + CheckedDiv<Output = Self>
     + Saturating
 {

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -1,7 +1,14 @@
 use core::ops::{Add, Div, Mul, Rem, Shl, Shr, Sub};
 
 /// Performs addition, returning `None` if overflow occurred.
+// FIXME: With a major version bump, this should not require `Add` supertrait
 pub trait CheckedAdd: Sized + Add<Self, Output = Self> {
+    /// Adds two numbers, checking for overflow. If overflow happens, `None` is
+    /// returned.
+    fn checked_add(&self, v: &Self) -> Option<Self>;
+}
+
+pub trait BaseCheckedAdd: Sized {
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
     fn checked_add(&self, v: &Self) -> Option<Self>;
@@ -18,12 +25,32 @@ macro_rules! checked_impl {
     };
 }
 
+macro_rules! nonzero_checked_impl {
+    ($trait_name:ident, $method:ident, $t:ty) => {
+        impl $trait_name for core::num::NonZero<$t> {
+            #[inline]
+            fn $method(&self, v: &core::num::NonZero<$t>) -> Option<core::num::NonZero<$t>> {
+                <$t>::$method((*self).get(), (*v).get()).map(|x| {
+                    core::num::NonZero::new(x).expect("checked sum of non zero is never zero")
+                })
+            }
+        }
+    };
+}
+
 checked_impl!(CheckedAdd, checked_add, u8);
 checked_impl!(CheckedAdd, checked_add, u16);
 checked_impl!(CheckedAdd, checked_add, u32);
 checked_impl!(CheckedAdd, checked_add, u64);
 checked_impl!(CheckedAdd, checked_add, usize);
 checked_impl!(CheckedAdd, checked_add, u128);
+
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, u8);
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, u16);
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, u32);
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, u64);
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, usize);
+nonzero_checked_impl!(BaseCheckedAdd, checked_add, u128);
 
 checked_impl!(CheckedAdd, checked_add, i8);
 checked_impl!(CheckedAdd, checked_add, i16);
@@ -54,7 +81,14 @@ checked_impl!(CheckedSub, checked_sub, isize);
 checked_impl!(CheckedSub, checked_sub, i128);
 
 /// Performs multiplication, returning `None` if overflow occurred.
+//FIXME: With a major version bump, this should not require `Mul` supertrait
 pub trait CheckedMul: Sized + Mul<Self, Output = Self> {
+    /// Multiplies two numbers, checking for overflow. If overflow happens,
+    /// `None` is returned.
+    fn checked_mul(&self, v: &Self) -> Option<Self>;
+}
+
+pub trait BaseCheckedMul: Sized {
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
     fn checked_mul(&self, v: &Self) -> Option<Self>;
@@ -66,6 +100,13 @@ checked_impl!(CheckedMul, checked_mul, u32);
 checked_impl!(CheckedMul, checked_mul, u64);
 checked_impl!(CheckedMul, checked_mul, usize);
 checked_impl!(CheckedMul, checked_mul, u128);
+
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, u8);
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, u16);
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, u32);
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, u64);
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, usize);
+nonzero_checked_impl!(BaseCheckedMul, checked_mul, u128);
 
 checked_impl!(CheckedMul, checked_mul, i8);
 checked_impl!(CheckedMul, checked_mul, i16);

--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -2,21 +2,28 @@ use core::ops::{Add, Div, Mul, Rem, Shl, Shr, Sub};
 
 /// Performs addition, returning `None` if overflow occurred.
 // FIXME: With a major version bump, this should not require `Add` supertrait
+#[cfg(not(feature = "unstable_1"))]
 pub trait CheckedAdd: Sized + Add<Self, Output = Self> {
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
     fn checked_add(&self, v: &Self) -> Option<Self>;
 }
 
-pub trait BaseCheckedAdd: Sized {
+/// Performs addition, returning `None` if overflow occurred.
+#[cfg(feature = "unstable_1")]
+pub trait CheckedAdd: Sized {
+    type Output;
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
-    fn checked_add(&self, v: &Self) -> Option<Self>;
+    fn checked_add(&self, v: &Self) -> Option<Self::Output>;
 }
+
 
 macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {
         impl $trait_name for $t {
+            #[cfg(feature = "unstable_1")]
+            type Output = $t;
             #[inline]
             fn $method(&self, v: &$t) -> Option<$t> {
                 <$t>::$method(*self, *v)
@@ -45,12 +52,16 @@ checked_impl!(CheckedAdd, checked_add, u64);
 checked_impl!(CheckedAdd, checked_add, usize);
 checked_impl!(CheckedAdd, checked_add, u128);
 
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, u8);
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, u16);
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, u32);
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, u64);
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, usize);
-nonzero_checked_impl!(BaseCheckedAdd, checked_add, u128);
+mod non_zero {
+    use super::*;
+    nonzero_checked_impl!(CheckedAdd, checked_add, u8);
+    nonzero_checked_impl!(CheckedAdd, checked_add, u16);
+    nonzero_checked_impl!(CheckedAdd, checked_add, u32);
+    nonzero_checked_impl!(CheckedAdd, checked_add, u64);
+    nonzero_checked_impl!(CheckedAdd, checked_add, usize);
+    nonzero_checked_impl!(CheckedAdd, checked_add, u128);
+}
+
 
 checked_impl!(CheckedAdd, checked_add, i8);
 checked_impl!(CheckedAdd, checked_add, i16);
@@ -73,6 +84,10 @@ checked_impl!(CheckedSub, checked_sub, u64);
 checked_impl!(CheckedSub, checked_sub, usize);
 checked_impl!(CheckedSub, checked_sub, u128);
 
+mod nonzero {
+    
+}
+
 checked_impl!(CheckedSub, checked_sub, i8);
 checked_impl!(CheckedSub, checked_sub, i16);
 checked_impl!(CheckedSub, checked_sub, i32);
@@ -82,17 +97,23 @@ checked_impl!(CheckedSub, checked_sub, i128);
 
 /// Performs multiplication, returning `None` if overflow occurred.
 //FIXME: With a major version bump, this should not require `Mul` supertrait
+#[cfg(not(feature = "unstable_1"))]
 pub trait CheckedMul: Sized + Mul<Self, Output = Self> {
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
     fn checked_mul(&self, v: &Self) -> Option<Self>;
 }
 
-pub trait BaseCheckedMul: Sized {
+/// Performs multiplication, returning `None` if overflow occurred.
+//FIXME: With a major version bump, this should not require `Mul` supertrait
+#[cfg(any(feature = "unstable_1"))]
+pub trait CheckedMul: Sized {
+    type Output;
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
-    fn checked_mul(&self, v: &Self) -> Option<Self>;
+    fn checked_mul(&self, v: &Self) -> Option<Self::Output>;
 }
+
 
 checked_impl!(CheckedMul, checked_mul, u8);
 checked_impl!(CheckedMul, checked_mul, u16);
@@ -101,12 +122,15 @@ checked_impl!(CheckedMul, checked_mul, u64);
 checked_impl!(CheckedMul, checked_mul, usize);
 checked_impl!(CheckedMul, checked_mul, u128);
 
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, u8);
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, u16);
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, u32);
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, u64);
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, usize);
-nonzero_checked_impl!(BaseCheckedMul, checked_mul, u128);
+mod nonzero {
+    use super::*;
+    nonzero_checked_impl!(CheckedMul, checked_mul, u8);
+    nonzero_checked_impl!(CheckedMul, checked_mul, u16);
+    nonzero_checked_impl!(CheckedMul, checked_mul, u32);
+    nonzero_checked_impl!(CheckedMul, checked_mul, u64);
+    nonzero_checked_impl!(CheckedMul, checked_mul, usize);
+    nonzero_checked_impl!(CheckedMul, checked_mul, u128);
+}
 
 checked_impl!(CheckedMul, checked_mul, i8);
 checked_impl!(CheckedMul, checked_mul, i16);

--- a/src/ops/mul_add.rs
+++ b/src/ops/mul_add.rs
@@ -67,8 +67,22 @@ macro_rules! mul_add_impl {
     )*}
 }
 
+macro_rules! nonzero_mul_add_impl {
+    ($trait_name:ident for $($t:ty)*) => {$(
+        impl $trait_name for core::num::NonZero<$t> {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self::Output {
+                core::num::NonZero::new((self.get() * a.get()) + b.get()).expect("non zero mul add is non zero")
+            }
+        }
+    )*}
+}
+
 mul_add_impl!(MulAdd for isize i8 i16 i32 i64 i128);
 mul_add_impl!(MulAdd for usize u8 u16 u32 u64 u128);
+nonzero_mul_add_impl!(MulAdd for usize u8 u16 u32 u64 u128);
 
 #[cfg(any(feature = "std", feature = "libm"))]
 impl MulAddAssign<f32, f32> for f32 {
@@ -97,8 +111,20 @@ macro_rules! mul_add_assign_impl {
     )*}
 }
 
+macro_rules! nonzero_mul_add_assign_impl {
+    ($trait_name:ident for $($t:ty)*) => {$(
+        impl $trait_name for core::num::NonZero<$t> {
+            #[inline]
+            fn mul_add_assign(&mut self, a: Self, b: Self) {
+                *self = core::num::NonZero::new((self.get() * a.get()) + b.get()).expect("non zero mul add assign is non zero")
+            }
+        }
+    )*}
+}
+
 mul_add_assign_impl!(MulAddAssign for isize i8 i16 i32 i64 i128);
 mul_add_assign_impl!(MulAddAssign for usize u8 u16 u32 u64 u128);
+nonzero_mul_add_assign_impl!(MulAddAssign for usize u8 u16 u32 u64 u128);
 
 #[cfg(test)]
 mod tests {

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -42,8 +42,27 @@ macro_rules! saturating_impl {
     };
 }
 
+macro_rules! nonzero_saturating_impl {
+    ($trait_name:ident, $method:ident, $t:ty) => {
+        impl $trait_name for core::num::NonZero<$t> {
+            #[inline]
+            fn $method(&self, v: &Self) -> Self {
+                core::num::NonZero::new(<$t>::$method((*self).get(), (*v).get()))
+                    .expect("non zero saturating operation is non zero")
+            }
+        }
+    };
+}
+
 /// Performs addition that saturates at the numeric bounds instead of overflowing.
+// FIXME: With a major version bump, this should not require `Add` supertrait
 pub trait SaturatingAdd: Sized + Add<Self, Output = Self> {
+    /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
+    /// the type.
+    fn saturating_add(&self, v: &Self) -> Self;
+}
+
+pub trait BaseSaturatingAdd: Sized {
     /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_add(&self, v: &Self) -> Self;
@@ -55,6 +74,13 @@ saturating_impl!(SaturatingAdd, saturating_add, u32);
 saturating_impl!(SaturatingAdd, saturating_add, u64);
 saturating_impl!(SaturatingAdd, saturating_add, usize);
 saturating_impl!(SaturatingAdd, saturating_add, u128);
+
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, u8);
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, u16);
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, u32);
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, u64);
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, usize);
+nonzero_saturating_impl!(BaseSaturatingAdd, saturating_add, u128);
 
 saturating_impl!(SaturatingAdd, saturating_add, i8);
 saturating_impl!(SaturatingAdd, saturating_add, i16);
@@ -85,7 +111,14 @@ saturating_impl!(SaturatingSub, saturating_sub, isize);
 saturating_impl!(SaturatingSub, saturating_sub, i128);
 
 /// Performs multiplication that saturates at the numeric bounds instead of overflowing.
+//FIXME: With a major version bump, this should not require `Mul` supertrait
 pub trait SaturatingMul: Sized + Mul<Self, Output = Self> {
+    /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
+    /// the type.
+    fn saturating_mul(&self, v: &Self) -> Self;
+}
+
+pub trait BaseSaturatingMul: Sized {
     /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
     /// the type.
     fn saturating_mul(&self, v: &Self) -> Self;
@@ -97,6 +130,13 @@ saturating_impl!(SaturatingMul, saturating_mul, u32);
 saturating_impl!(SaturatingMul, saturating_mul, u64);
 saturating_impl!(SaturatingMul, saturating_mul, usize);
 saturating_impl!(SaturatingMul, saturating_mul, u128);
+
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, u8);
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, u16);
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, u32);
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, u64);
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, usize);
+nonzero_saturating_impl!(BaseSaturatingMul, saturating_mul, u128);
 
 saturating_impl!(SaturatingMul, saturating_mul, i8);
 saturating_impl!(SaturatingMul, saturating_mul, i16);


### PR DESCRIPTION
TLDR;

- need new major release bump
- saturating sub works only for self minus self outputs self and requires sub, which is not the case generally
- etc

LONG:

Covers what can work for current stable non zero.

What can be done?
1. detect Rust/MSRV lang version and gate `NonZero<T>` since it was introduced. Easy, dtolnay doing that.
2. detect this crate version major bump, and change `base` traits relations. So we do not need `Add`/`Mul` on non zeros. add VERSION_NUMBER_UNSTABLE feature like. So as for now just add new base traits.
3. One. Seems reasonable to add, but it tells some MATH props on interface, I can reproduce it without need to `Mul`, with Checked only. 
4. Port tests  and some cast support from https://github.com/rust-num/num-traits/pull/334 .Differs from #334 by using generics.

I can do any version detection (Package/Rust) so can ensure it switched automatically.

Partially overlaps with next, but not same:

https://github.com/rust-num/num-traits/issues/85

https://github.com/rust-num/num-traits/issues/215