### PR TITLE
Add `round_ties_even` to `Float/Core` and `Real`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
           1.60.0, # MSRV
           1.62.0, # has_total_cmp
           1.74.0, # has_num_saturating
+          1.77.0, # has_round_ties_even
           stable,
           beta,
           nightly,

--- a/build.rs
+++ b/build.rs
@@ -5,5 +5,9 @@ fn main() {
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
     ac.emit_path_cfg("core::num::Saturating", "has_num_saturating"); // 1.74
 
+    // round_ties_even is only available in `std`
+    ac.set_no_std(false);
+    ac.emit_expression_cfg("1.5f64.round_ties_even()", "has_round_ties_even"); // 1.77
+
     autocfg::rerun_path("build.rs");
 }

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.60.0 1.62.0 1.74.0 stable beta nightly; do
+for version in 1.60.0 1.62.0 1.74.0 1.77.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,3 +42,31 @@ macro_rules! constant {
             }
         )*};
 }
+
+/// Pulling out the inner implementation of a default `round_ties_even` to allow
+/// reuse across the various relevant traits.
+macro_rules! round_ties_even_impl {
+    ($self:ident) => {{
+        let half = (Self::one() + Self::one()).recip();
+
+        if $self.fract().abs() != half {
+            $self.round()
+        } else {
+            let i = $self.abs().trunc();
+
+            let value = if (i * half).fract() == half {
+                // -1.5, 1.5, 3.5, ...
+                $self.abs() + half
+            } else {
+                // -0.5, 0.5, 2.5, ...
+                $self.abs() - half
+            };
+
+            if $self.signum() != value.signum() {
+                -value
+            } else {
+                value
+            }
+        }
+    }};
+}

--- a/src/real.rs
+++ b/src/real.rs
@@ -107,6 +107,29 @@ pub trait Real: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     /// ```
     fn round(self) -> Self;
 
+    /// Rounds to the nearest integer, with ties biasing towards an even result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_traits::real::Real;
+    ///
+    /// fn check<T: Real>(x: T, rounded: T) {
+    ///     assert!(x.round_ties_even() == rounded);
+    /// }
+    ///
+    /// check(1.0f32, 1.0);
+    /// check(1.25f32, 1.0);
+    /// check(1.75f32, 2.0);
+    /// check(1.5f32, 2.0);
+    /// check(2.5f32, 2.0);
+    /// check(3.5f32, 4.0);
+    /// check(-3.5f32, -4.0);
+    /// ```
+    fn round_ties_even(self) -> Self {
+        round_ties_even_impl!(self)
+    }
+
     /// Return the integer part of a number.
     ///
     /// ```
@@ -830,5 +853,6 @@ impl<T: Float> Real for T {
         Float::asinh(self) -> Self;
         Float::acosh(self) -> Self;
         Float::atanh(self) -> Self;
+        Float::round_ties_even(self) -> Self;
     }
 }


### PR DESCRIPTION
# Objective

Since Rust 1.77, [`round_ties_even`](https://doc.rust-lang.org/std/primitive.f32.html#method.round_ties_even) was added to `f32` and `f64` in the standard library. This function is used within [WGPU](https://github.com/gfx-rs/wgpu), and as a part of a push for [`no_std` support](https://github.com/gfx-rs/wgpu/issues/6826), this function will need to be shimmed. It could be shimmed within Naga, but this functionality may have value to other users of `num-traits`.

## Solution

- Added `round_ties_even` to `FloatCore`, `Float`, and `Real` with a default implementation (not a breaking change)
- Added a `has_round_ties_even` configuration check to allow detecting `round_ties_even` provided by the standard library in Rust 1.77 and above (not a breaking change)
- Added a test ensuring the fallback implementation of `round_ties_even` matches the implementation in `std` for the `f32` type (assuming it is equally valid for `f64`)

---

## Notes

- ~~The `msrv_1_77` feature increases MSRV to 1.77, which is a typical arrangement (e.g., `serde` features will typically elevate MSRV). If/when `num-traits` advances past MSRV 1.77, this feature can become a no-op without any breaking changes.~~ Resolved using `build.rs` and `autocfg`.
- This is my first contribution to `num-traits`, please let me know if there's anything I can do to help!