### PR TITLE
Make the build reproducible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ i128 = []
 
 [build-dependencies]
 autocfg = "1"
+tempfile = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    let ac = autocfg::new();
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let ac = autocfg::AutoCfg::with_dir(temp_dir.path()).unwrap();
 
     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
 


### PR DESCRIPTION
numtraits' build script causes non-reproducible autocfg's files to be written to `OUT_DIR`:
```
$ cargo build
...
$ ls -la target/debug/build/num-traits-1caa1923b38178a5/out
total 24
drwxrwxr-x 2 bas bas 4096 May 14 10:20 .
drwxrwxr-x 3 bas bas 4096 May 14 10:15 ..
-rw-rw-r-- 1 bas bas  460 May 14 10:20 autocfg_02ed89fc39f41e87_0.ll
-rw-rw-r-- 1 bas bas 2445 May 14 10:20 autocfg_02ed89fc39f41e87_1.ll
```
Those hashes in the filenames and the contents of the files will be different for every build.

This causes issues in build systems like bazel with rules_rust that treat `OUT_DIR` as the package's output. Since the output is different for every build it means reverse dependencies of num-traits have to be rebuild every time num-traits changes.

We fix this by adapting the build script to let autocfg write its intermediate files to a temporary directory.