### PR TITLE
Add links to num-integer crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Numeric traits for generic mathematics in Rust.
 
+See the [`num-integer`](https://docs.rs/num-integer/) crate for the `Integer` trait.
+
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 
 //! Numeric traits for generic mathematics
 //!
+//! See the [`num-integer`](https://docs.rs/num-integer/) crate for the `Integer` trait.
+//!
 //! ## Compatibility
 //!
 //! The `num-traits` crate is tested for rustc 1.60 and greater.


### PR DESCRIPTION
It is very confusing as a user that `num-traits` contains the `Real` trait, but not the `Integer` trait.

See for instance https://github.com/rust-num/num-traits/issues/219 and https://github.com/rust-num/num-traits/issues/357.

Having a link in the documentation and README could help the user find the `Integer` trait.