### PR TITLE
Introduce the UnsignedAbs trait 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::ops::wrapping::{
     WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr, WrappingSub,
 };
 pub use crate::pow::{checked_pow, pow, Pow};
-pub use crate::sign::{abs, abs_sub, signum, Signed, Unsigned};
+pub use crate::sign::{abs, abs_sub, signum, Signed, Unsigned, UnsignedAbs};
 
 #[macro_use]
 mod macros;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -214,3 +214,45 @@ fn signed_wrapping_is_signed() {
     fn require_signed<T: Signed>(_: &T) {}
     require_signed(&Wrapping(-42));
 }
+
+/// A trait for values which can be converted to an unsigned type with the unsigned_abs utility method.
+pub trait UnsignedAbs {
+    type Unsigned;
+
+    fn unsigned_abs(&self) -> Self::Unsigned;
+}
+
+macro_rules! unsigned_abs_impl {
+    ($($t:ty:$ut:ty),*) => ($(
+        impl UnsignedAbs for $t {
+            type Unsigned = $ut;
+
+            #[inline(always)]
+            fn unsigned_abs(&self) -> Self::Unsigned {
+                <$t>::unsigned_abs(*self)
+            }
+        }
+    )*)
+}
+
+unsigned_abs_impl!(i8:u8, i16:u16, i32:u32, i64:u64, i128:u128, isize:usize);
+
+#[test]
+fn unsigned_abs_test() {
+    fn require_unsigned_abs<T: UnsignedAbs>(_: &T) {}
+
+    require_unsigned_abs(&-42_i8);
+    require_unsigned_abs(&-42_i16);
+    require_unsigned_abs(&-42_i32);
+    require_unsigned_abs(&-42_i64);
+    require_unsigned_abs(&-42_i128);
+    require_unsigned_abs(&-42_isize);
+
+    assert_eq!((-42_i8).unsigned_abs(), 42_u8);
+    assert_eq!(42_i8.unsigned_abs(), 42_u8);
+    assert_eq!(i8::MIN.unsigned_abs(), 128_u8);
+
+    assert_eq!((-42_i32).unsigned_abs(), 42_u32);
+    assert_eq!(42_i32.unsigned_abs(), 42_u32);
+    assert_eq!(i32::MIN.unsigned_abs(), 2147483648_u32);
+}

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -2,7 +2,7 @@ use core::num::Wrapping;
 use core::ops::Neg;
 
 use crate::float::FloatCore;
-use crate::Num;
+use crate::{Num, PrimInt};
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Sized + Num + Neg<Output = Self> {
@@ -217,7 +217,7 @@ fn signed_wrapping_is_signed() {
 
 /// A trait for values which can be converted to an unsigned type with the unsigned_abs utility method.
 pub trait UnsignedAbs {
-    type Unsigned;
+    type Unsigned: PrimInt + Unsigned;
 
     fn unsigned_abs(&self) -> Self::Unsigned;
 }


### PR DESCRIPTION
This change adds the UnsignedAbs trait as discussed in https://github.com/rust-num/num-traits/issues/315 based on the investigation and testing done by [@emilk](https://github.com/emilk).