### PR TITLE
feat: propagate `<Rhs = Self>` type parameter to trait bounds

### DIFF
--- a/src/ops/checked.rs
+++ b/src/ops/checked.rs
@@ -1,10 +1,10 @@
 use core::ops::{Add, Div, Mul, Rem, Shl, Shr, Sub};
 
 /// Performs addition, returning `None` if overflow occurred.
-pub trait CheckedAdd: Sized + Add<Self, Output = Self> {
+pub trait CheckedAdd<Rhs = Self>: Sized + Add<Rhs, Output = Self> {
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is
     /// returned.
-    fn checked_add(&self, v: &Self) -> Option<Self>;
+    fn checked_add(&self, v: &Rhs) -> Option<Self>;
 }
 
 macro_rules! checked_impl {
@@ -33,10 +33,10 @@ checked_impl!(CheckedAdd, checked_add, isize);
 checked_impl!(CheckedAdd, checked_add, i128);
 
 /// Performs subtraction, returning `None` if overflow occurred.
-pub trait CheckedSub: Sized + Sub<Self, Output = Self> {
+pub trait CheckedSub<Rhs = Self>: Sized + Sub<Rhs, Output = Self> {
     /// Subtracts two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
-    fn checked_sub(&self, v: &Self) -> Option<Self>;
+    fn checked_sub(&self, v: &Rhs) -> Option<Self>;
 }
 
 checked_impl!(CheckedSub, checked_sub, u8);
@@ -54,10 +54,10 @@ checked_impl!(CheckedSub, checked_sub, isize);
 checked_impl!(CheckedSub, checked_sub, i128);
 
 /// Performs multiplication, returning `None` if overflow occurred.
-pub trait CheckedMul: Sized + Mul<Self, Output = Self> {
+pub trait CheckedMul<Rhs = Self>: Sized + Mul<Rhs, Output = Self> {
     /// Multiplies two numbers, checking for overflow. If overflow happens,
     /// `None` is returned.
-    fn checked_mul(&self, v: &Self) -> Option<Self>;
+    fn checked_mul(&self, v: &Rhs) -> Option<Self>;
 }
 
 checked_impl!(CheckedMul, checked_mul, u8);
@@ -76,10 +76,10 @@ checked_impl!(CheckedMul, checked_mul, i128);
 
 /// Performs division, returning `None` on division by zero or if overflow
 /// occurred.
-pub trait CheckedDiv: Sized + Div<Self, Output = Self> {
+pub trait CheckedDiv<Rhs = Self>: Sized + Div<Rhs, Output = Self> {
     /// Divides two numbers, checking for overflow and division by
     /// zero. If any of that happens, `None` is returned.
-    fn checked_div(&self, v: &Self) -> Option<Self>;
+    fn checked_div(&self, v: &Rhs) -> Option<Self>;
 }
 
 checked_impl!(CheckedDiv, checked_div, u8);
@@ -98,7 +98,7 @@ checked_impl!(CheckedDiv, checked_div, i128);
 
 /// Performs integral remainder, returning `None` on division by zero or if
 /// overflow occurred.
-pub trait CheckedRem: Sized + Rem<Self, Output = Self> {
+pub trait CheckedRem<Rhs = Self>: Sized + Rem<Rhs, Output = Self> {
     /// Finds the remainder of dividing two numbers, checking for overflow and
     /// division by zero. If any of that happens, `None` is returned.
     ///
@@ -118,7 +118,7 @@ pub trait CheckedRem: Sized + Rem<Self, Output = Self> {
     /// assert_eq!(CheckedRem::checked_rem(&MIN, &1), Some(0));
     /// assert_eq!(CheckedRem::checked_rem(&MIN, &-1), None);
     /// ```
-    fn checked_rem(&self, v: &Self) -> Option<Self>;
+    fn checked_rem(&self, v: &Rhs) -> Option<Self>;
 }
 
 checked_impl!(CheckedRem, checked_rem, u8);
@@ -183,7 +183,7 @@ checked_impl_unary!(CheckedNeg, checked_neg, i128);
 
 /// Performs shift left, returning `None` on shifts larger than or equal to
 /// the type width.
-pub trait CheckedShl: Sized + Shl<u32, Output = Self> {
+pub trait CheckedShl<Rhs = u32>: Sized + Shl<Rhs, Output = Self> {
     /// Checked shift left. Computes `self << rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
@@ -197,7 +197,7 @@ pub trait CheckedShl: Sized + Shl<u32, Output = Self> {
     /// assert_eq!(CheckedShl::checked_shl(&x, 15), Some(0x8000));
     /// assert_eq!(CheckedShl::checked_shl(&x, 16), None);
     /// ```
-    fn checked_shl(&self, rhs: u32) -> Option<Self>;
+    fn checked_shl(&self, rhs: Rhs) -> Option<Self>;
 }
 
 macro_rules! checked_shift_impl {
@@ -227,7 +227,7 @@ checked_shift_impl!(CheckedShl, checked_shl, i128);
 
 /// Performs shift right, returning `None` on shifts larger than or equal to
 /// the type width.
-pub trait CheckedShr: Sized + Shr<u32, Output = Self> {
+pub trait CheckedShr<Rhs = u32>: Sized + Shr<Rhs, Output = Self> {
     /// Checked shift right. Computes `self >> rhs`, returning `None`
     /// if `rhs` is larger than or equal to the number of bits in `self`.
     ///
@@ -241,7 +241,7 @@ pub trait CheckedShr: Sized + Shr<u32, Output = Self> {
     /// assert_eq!(CheckedShr::checked_shr(&x, 15), Some(0x0001));
     /// assert_eq!(CheckedShr::checked_shr(&x, 16), None);
     /// ```
-    fn checked_shr(&self, rhs: u32) -> Option<Self>;
+    fn checked_shr(&self, rhs: Rhs) -> Option<Self>;
 }
 
 checked_shift_impl!(CheckedShr, checked_shr, u8);

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -1,6 +1,6 @@
 use core::ops::{Div, Rem};
 
-pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
+pub trait Euclid<Rhs = Self>: Sized + Div<Rhs, Output = Self> + Rem<Rhs, Output = Self> {
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
     ///
     /// This computes the integer `n` such that
@@ -20,7 +20,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     /// assert_eq!(Euclid::div_euclid(&a, &-b), -1); // 7 >= -4 * -1
     /// assert_eq!(Euclid::div_euclid(&-a, &-b), 2); // -7 >= -4 * 2
     /// ```
-    fn div_euclid(&self, v: &Self) -> Self;
+    fn div_euclid(&self, v: &Rhs) -> Self;
 
     /// Calculates the least nonnegative remainder of `self (mod v)`.
     ///
@@ -45,7 +45,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     /// assert_eq!(Euclid::rem_euclid(&a, &-b), 3);
     /// assert_eq!(Euclid::rem_euclid(&-a, &-b), 1);
     /// ```
-    fn rem_euclid(&self, v: &Self) -> Self;
+    fn rem_euclid(&self, v: &Rhs) -> Self;
 
     /// Returns both the quotient and remainder from Euclidean division.
     ///
@@ -64,7 +64,7 @@ pub trait Euclid: Sized + Div<Self, Output = Self> + Rem<Self, Output = Self> {
     ///
     /// assert_eq!((div, rem), Euclid::div_rem_euclid(&x, &y));
     /// ```
-    fn div_rem_euclid(&self, v: &Self) -> (Self, Self) {
+    fn div_rem_euclid(&self, v: &Rhs) -> (Self, Self) {
         (self.div_euclid(v), self.rem_euclid(v))
     }
 }
@@ -135,14 +135,14 @@ impl Euclid for f64 {
     }
 }
 
-pub trait CheckedEuclid: Euclid {
+pub trait CheckedEuclid<Rhs = Self>: Euclid<Rhs> {
     /// Performs euclid division, returning `None` on division by zero or if
     /// overflow occurred.
-    fn checked_div_euclid(&self, v: &Self) -> Option<Self>;
+    fn checked_div_euclid(&self, v: &Rhs) -> Option<Self>;
 
     /// Finds the euclid remainder of dividing two numbers, returning `None` on
     /// division by zero or if overflow occurred.
-    fn checked_rem_euclid(&self, v: &Self) -> Option<Self>;
+    fn checked_rem_euclid(&self, v: &Rhs) -> Option<Self>;
 
     /// Returns both the quotient and remainder from checked Euclidean division,
     /// returning `None` on division by zero or if overflow occurred.
@@ -161,7 +161,7 @@ pub trait CheckedEuclid: Euclid {
     ///
     /// assert_eq!(Some((div.unwrap(), rem.unwrap())), CheckedEuclid::checked_div_rem_euclid(&x, &y));
     /// ```
-    fn checked_div_rem_euclid(&self, v: &Self) -> Option<(Self, Self)> {
+    fn checked_div_rem_euclid(&self, v: &Rhs) -> Option<(Self, Self)> {
         Some((self.checked_div_euclid(v)?, self.checked_rem_euclid(v)?))
     }
 }

--- a/src/ops/overflowing.rs
+++ b/src/ops/overflowing.rs
@@ -14,10 +14,10 @@ macro_rules! overflowing_impl {
 }
 
 /// Performs addition with a flag for overflow.
-pub trait OverflowingAdd: Sized + Add<Self, Output = Self> {
+pub trait OverflowingAdd<Rhs = Self>: Sized + Add<Rhs, Output = Self> {
     /// Returns a tuple of the sum along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_add(&self, v: &Self) -> (Self, bool);
+    fn overflowing_add(&self, v: &Rhs) -> (Self, bool);
 }
 
 overflowing_impl!(OverflowingAdd, overflowing_add, u8);
@@ -35,10 +35,10 @@ overflowing_impl!(OverflowingAdd, overflowing_add, isize);
 overflowing_impl!(OverflowingAdd, overflowing_add, i128);
 
 /// Performs substraction with a flag for overflow.
-pub trait OverflowingSub: Sized + Sub<Self, Output = Self> {
+pub trait OverflowingSub<Rhs = Self>: Sized + Sub<Rhs, Output = Self> {
     /// Returns a tuple of the difference along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_sub(&self, v: &Self) -> (Self, bool);
+    fn overflowing_sub(&self, v: &Rhs) -> (Self, bool);
 }
 
 overflowing_impl!(OverflowingSub, overflowing_sub, u8);
@@ -56,10 +56,10 @@ overflowing_impl!(OverflowingSub, overflowing_sub, isize);
 overflowing_impl!(OverflowingSub, overflowing_sub, i128);
 
 /// Performs multiplication with a flag for overflow.
-pub trait OverflowingMul: Sized + Mul<Self, Output = Self> {
+pub trait OverflowingMul<Rhs = Self>: Sized + Mul<Rhs, Output = Self> {
     /// Returns a tuple of the product along with a boolean indicating whether an arithmetic overflow would occur.
     /// If an overflow would have occurred then the wrapped value is returned.
-    fn overflowing_mul(&self, v: &Self) -> (Self, bool);
+    fn overflowing_mul(&self, v: &Rhs) -> (Self, bool);
 }
 
 overflowing_impl!(OverflowingMul, overflowing_mul, u8);

--- a/src/ops/saturating.rs
+++ b/src/ops/saturating.rs
@@ -43,10 +43,10 @@ macro_rules! saturating_impl {
 }
 
 /// Performs addition that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingAdd: Sized + Add<Self, Output = Self> {
+pub trait SaturatingAdd<Rhs = Self>: Sized + Add<Rhs, Output = Self> {
     /// Saturating addition. Computes `self + other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_add(&self, v: &Self) -> Self;
+    fn saturating_add(&self, v: &Rhs) -> Self;
 }
 
 saturating_impl!(SaturatingAdd, saturating_add, u8);
@@ -64,10 +64,10 @@ saturating_impl!(SaturatingAdd, saturating_add, isize);
 saturating_impl!(SaturatingAdd, saturating_add, i128);
 
 /// Performs subtraction that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingSub: Sized + Sub<Self, Output = Self> {
+pub trait SaturatingSub<Rhs = Self>: Sized + Sub<Rhs, Output = Self> {
     /// Saturating subtraction. Computes `self - other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_sub(&self, v: &Self) -> Self;
+    fn saturating_sub(&self, v: &Rhs) -> Self;
 }
 
 saturating_impl!(SaturatingSub, saturating_sub, u8);
@@ -85,10 +85,10 @@ saturating_impl!(SaturatingSub, saturating_sub, isize);
 saturating_impl!(SaturatingSub, saturating_sub, i128);
 
 /// Performs multiplication that saturates at the numeric bounds instead of overflowing.
-pub trait SaturatingMul: Sized + Mul<Self, Output = Self> {
+pub trait SaturatingMul<Rhs = Self>: Sized + Mul<Rhs, Output = Self> {
     /// Saturating multiplication. Computes `self * other`, saturating at the relevant high or low boundary of
     /// the type.
-    fn saturating_mul(&self, v: &Self) -> Self;
+    fn saturating_mul(&self, v: &Rhs) -> Self;
 }
 
 saturating_impl!(SaturatingMul, saturating_mul, u8);

--- a/src/ops/wrapping.rs
+++ b/src/ops/wrapping.rs
@@ -21,10 +21,10 @@ macro_rules! wrapping_impl {
 }
 
 /// Performs addition that wraps around on overflow.
-pub trait WrappingAdd: Sized + Add<Self, Output = Self> {
+pub trait WrappingAdd<Rhs = Self>: Sized + Add<Rhs, Output = Self> {
     /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of
     /// the type.
-    fn wrapping_add(&self, v: &Self) -> Self;
+    fn wrapping_add(&self, v: &Rhs) -> Self;
 }
 
 wrapping_impl!(WrappingAdd, wrapping_add, u8);
@@ -42,10 +42,10 @@ wrapping_impl!(WrappingAdd, wrapping_add, isize);
 wrapping_impl!(WrappingAdd, wrapping_add, i128);
 
 /// Performs subtraction that wraps around on overflow.
-pub trait WrappingSub: Sized + Sub<Self, Output = Self> {
+pub trait WrappingSub<Rhs = Self>: Sized + Sub<Rhs, Output = Self> {
     /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary
     /// of the type.
-    fn wrapping_sub(&self, v: &Self) -> Self;
+    fn wrapping_sub(&self, v: &Rhs) -> Self;
 }
 
 wrapping_impl!(WrappingSub, wrapping_sub, u8);
@@ -63,10 +63,10 @@ wrapping_impl!(WrappingSub, wrapping_sub, isize);
 wrapping_impl!(WrappingSub, wrapping_sub, i128);
 
 /// Performs multiplication that wraps around on overflow.
-pub trait WrappingMul: Sized + Mul<Self, Output = Self> {
+pub trait WrappingMul<Rhs = Self>: Sized + Mul<Rhs, Output = Self> {
     /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary
     /// of the type.
-    fn wrapping_mul(&self, v: &Self) -> Self;
+    fn wrapping_mul(&self, v: &Rhs) -> Self;
 }
 
 wrapping_impl!(WrappingMul, wrapping_mul, u8);
@@ -141,7 +141,7 @@ macro_rules! wrapping_shift_impl {
 }
 
 /// Performs a left shift that does not panic.
-pub trait WrappingShl: Sized + Shl<usize, Output = Self> {
+pub trait WrappingShl<Rhs = u32>: Sized + Shl<usize, Output = Self> {
     /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
@@ -156,7 +156,7 @@ pub trait WrappingShl: Sized + Shl<usize, Output = Self> {
     /// assert_eq!(WrappingShl::wrapping_shl(&x, 15), 0x8000);
     /// assert_eq!(WrappingShl::wrapping_shl(&x, 16), 0x0001);
     /// ```
-    fn wrapping_shl(&self, rhs: u32) -> Self;
+    fn wrapping_shl(&self, rhs: Rhs) -> Self;
 }
 
 wrapping_shift_impl!(WrappingShl, wrapping_shl, u8);
@@ -174,7 +174,7 @@ wrapping_shift_impl!(WrappingShl, wrapping_shl, isize);
 wrapping_shift_impl!(WrappingShl, wrapping_shl, i128);
 
 /// Performs a right shift that does not panic.
-pub trait WrappingShr: Sized + Shr<usize, Output = Self> {
+pub trait WrappingShr<Rhs = u32>: Sized + Shr<usize, Output = Self> {
     /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
     /// where `mask` removes any high order bits of `rhs` that would
     /// cause the shift to exceed the bitwidth of the type.
@@ -189,7 +189,7 @@ pub trait WrappingShr: Sized + Shr<usize, Output = Self> {
     /// assert_eq!(WrappingShr::wrapping_shr(&x, 15), 0x0001);
     /// assert_eq!(WrappingShr::wrapping_shr(&x, 16), 0x8000);
     /// ```
-    fn wrapping_shr(&self, rhs: u32) -> Self;
+    fn wrapping_shr(&self, rhs: Rhs) -> Self;
 }
 
 wrapping_shift_impl!(WrappingShr, wrapping_shr, u8);
@@ -239,19 +239,19 @@ where
         Wrapping(self.0.wrapping_neg())
     }
 }
-impl<T: WrappingShl> WrappingShl for Wrapping<T>
+impl<Rhs, T: WrappingShl<Rhs>> WrappingShl<Rhs> for Wrapping<T>
 where
     Wrapping<T>: Shl<usize, Output = Wrapping<T>>,
 {
-    fn wrapping_shl(&self, rhs: u32) -> Self {
+    fn wrapping_shl(&self, rhs: Rhs) -> Self {
         Wrapping(self.0.wrapping_shl(rhs))
     }
 }
-impl<T: WrappingShr> WrappingShr for Wrapping<T>
+impl<Rhs, T: WrappingShr<Rhs>> WrappingShr<Rhs> for Wrapping<T>
 where
     Wrapping<T>: Shr<usize, Output = Wrapping<T>>,
 {
-    fn wrapping_shr(&self, rhs: u32) -> Self {
+    fn wrapping_shr(&self, rhs: Rhs) -> Self {
         Wrapping(self.0.wrapping_shr(rhs))
     }
 }


### PR DESCRIPTION
This PR extends following traits with `<Rhs = Self>` type parameter relaxing the trait bound requirements, while maintaining backwards-compatibility:
* `CheckedAdd`
* `CheckedSub`
* `CheckedMul`
* `CheckedDiv`
* `CheckedRem`
* `CheckedShl`
* `CheckedShr`
* `Euclid`
* `CheckedEuclid`
* `OverflowingAdd`
* `OverflowingSub`
* `OverflowingMul`
* `SaturatingAdd`
* `SaturatingSub`
* `SaturatingMul`
* `WrappingAdd`
* `WrappingSub`
* `WrappingMul`
* `WrappingShl`
* `WrappingShr`