### PR TITLE
Add a feature to enforce `libm` in `std` environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ libm = { version = "0.2.0", optional = true }
 default = ["std"]
 libm = ["dep:libm"]
 std = []
+force-libm = ["libm"]
 
 # vestigial features, now always in effect
 i128 = []

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -27,7 +27,7 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
-FEATURES=(libm)
+FEATURES=(libm force-libm)
 echo "Testing supported features: ${FEATURES[*]}"
 
 cargo generate-lockfile

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -58,3 +58,23 @@ cargo test --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
 cargo test --features="${FEATURES[*]}"
+
+# Verify that `force-libm` feature actually switches the math implementation
+# by checking for libm symbols in the linked test binary.
+get_test_binary() {
+  cargo test --no-run --no-default-features --features="$1" --message-format=json 2>/dev/null \
+    | grep '"name":"num_traits"' \
+    | sed -n 's/.*"executable":"\([^"]*\)".*/\1/p'
+}
+
+echo "Checking that test binary built with only the 'std' feature DOES NOT contain libm math symbols..."
+if nm -C "$(get_test_binary "std")" | grep -q 'libm::math'; then
+  echo "force-libm symbol check failed: std-only binary should not contain libm math symbols"
+  exit 1
+fi
+
+echo "Checking that test binary built with 'std' and 'force-libm' features DOES contain libm math symbols..."
+if ! nm -C "$(get_test_binary "std,force-libm")" | grep -q 'libm::math'; then
+  echo "force-libm symbol check failed: force-libm binary should contain libm math symbols"
+  exit 1
+fi

--- a/src/float.rs
+++ b/src/float.rs
@@ -832,7 +832,7 @@ impl FloatCore for f32 {
         Self::to_radians(self) -> Self;
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", not(feature = "force-libm")))]
     forward! {
         Self::floor(self) -> Self;
         Self::ceil(self) -> Self;
@@ -844,7 +844,7 @@ impl FloatCore for f32 {
         Self::powi(self, n: i32) -> Self;
     }
 
-    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    #[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
     forward! {
         libm::floorf as floor(self) -> Self;
         libm::ceilf as ceil(self) -> Self;
@@ -853,7 +853,7 @@ impl FloatCore for f32 {
         libm::fabsf as abs(self) -> Self;
     }
 
-    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    #[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
     #[inline]
     fn fract(self) -> Self {
         self - libm::truncf(self)
@@ -894,7 +894,7 @@ impl FloatCore for f64 {
         Self::to_radians(self) -> Self;
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", not(feature = "force-libm")))]
     forward! {
         Self::floor(self) -> Self;
         Self::ceil(self) -> Self;
@@ -906,7 +906,7 @@ impl FloatCore for f64 {
         Self::powi(self, n: i32) -> Self;
     }
 
-    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    #[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
     forward! {
         libm::floor as floor(self) -> Self;
         libm::ceil as ceil(self) -> Self;
@@ -915,7 +915,7 @@ impl FloatCore for f64 {
         libm::fabs as abs(self) -> Self;
     }
 
-    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    #[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
     #[inline]
     fn fract(self) -> Self {
         self - libm::trunc(self)
@@ -1911,7 +1911,7 @@ pub trait Float: Num + Copy + NumCast + PartialOrd + Neg<Output = Self> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "force-libm")))]
 macro_rules! float_impl_std {
     ($T:ident $decode:ident) => {
         impl Float for $T {
@@ -1993,7 +1993,7 @@ macro_rules! float_impl_std {
     };
 }
 
-#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
 macro_rules! float_impl_libm {
     ($T:ident $decode:ident) => {
         constant! {
@@ -2074,12 +2074,12 @@ fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     (mantissa, exponent, sign)
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "force-libm")))]
 float_impl_std!(f32 integer_decode_f32);
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "force-libm")))]
 float_impl_std!(f64 integer_decode_f64);
 
-#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
 impl Float for f32 {
     float_impl_libm!(f32 integer_decode_f32);
 
@@ -2125,7 +2125,7 @@ impl Float for f32 {
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]
 impl Float for f64 {
     float_impl_libm!(f64 integer_decode_f64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ macro_rules! float_trait_impl {
                             None             => return Err(PFE { kind: Invalid }),
                         };
 
-                        #[cfg(feature = "std")]
+                        #[cfg(all(feature = "std", not(feature = "force-libm")))]
                         fn pow(base: $t, exp: usize) -> $t {
                             Float::powi(base, exp as i32)
                         }

--- a/src/ops/euclid.rs
+++ b/src/ops/euclid.rs
@@ -88,10 +88,10 @@ macro_rules! euclid_forward_impl {
 euclid_forward_impl!(isize i8 i16 i32 i64 i128);
 euclid_forward_impl!(usize u8 u16 u32 u64 u128);
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "force-libm")))]
 euclid_forward_impl!(f32 f64);
 
-#[cfg(not(feature = "std"))]
+#[cfg(any(feature = "force-libm", not(feature = "std")))]
 impl Euclid for f32 {
     #[inline]
     fn div_euclid(&self, v: &f32) -> f32 {
@@ -113,7 +113,7 @@ impl Euclid for f32 {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(any(feature = "force-libm", not(feature = "std")))]
 impl Euclid for f64 {
     #[inline]
     fn div_euclid(&self, v: &f64) -> f64 {


### PR DESCRIPTION
This pull request adds a feature named `force-libm` to num-traits.

# Why

Currently, when both `std` and `libm` features are enabled, `std` always wins due to the `not(feature = "std")` guard on the libm code paths. There is no way to use `libm` implementations in an `std` environment afaik.

This is something I need for reproducible cross-platform float math and, since I saw not open issue regarding this,I chose to propose my solution if you are interested.

# How

I added a new cumulative `force-libm` Cargo feature which implies that `libm` is also enabled. It can be combined with `std` (for everything else std provides) while routing float math through `libm`.    
When enabled, it overrides `std` for float math operations by changing the conditional compilation gates:
- `#[cfg(feature = "std")]` on math impls becomes `#[cfg(all(feature = "std", not(feature = "force-libm")))]`
- `#[cfg(all(not(feature = "std"), feature = "libm"))]` becomes `#[cfg(any(feature = "force-libm", all(not(feature = "std"), feature = "libm")))]`

I also updated `test_full.sh` to verifies that the feature works. It checks that the linked test binary contains `libm::math` symbols when `force-libm` is enabled and does not when using `std` alone.    
This is the only reliable solution I found but feel free to propose other solution.

---

Thank you for your work in maintaining this project 😄 
